### PR TITLE
feat: add iostreams TTY-aware I/O abstraction (#2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/qubernetic-org/copia-cli
 
 go 1.23
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -1,0 +1,58 @@
+package iostreams
+
+import (
+	"bytes"
+	"io"
+	"os"
+)
+
+// IOStreams provides TTY-aware I/O for commands.
+type IOStreams struct {
+	In     io.ReadCloser
+	Out    io.Writer
+	ErrOut io.Writer
+
+	stdinIsTTY  bool
+	stdoutIsTTY bool
+	stderrIsTTY bool
+}
+
+// System returns IOStreams connected to real stdin/stdout/stderr.
+func System() *IOStreams {
+	return &IOStreams{
+		In:          os.Stdin,
+		Out:         os.Stdout,
+		ErrOut:      os.Stderr,
+		stdinIsTTY:  isTerminal(os.Stdin),
+		stdoutIsTTY: isTerminal(os.Stdout),
+		stderrIsTTY: isTerminal(os.Stderr),
+	}
+}
+
+// Test returns IOStreams with in-memory buffers for testing.
+func Test() (*IOStreams, *bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {
+	stdin := &bytes.Buffer{}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	return &IOStreams{
+		In:     io.NopCloser(stdin),
+		Out:    stdout,
+		ErrOut: stderr,
+	}, stdin, stdout, stderr
+}
+
+func (s *IOStreams) IsStdinTTY() bool  { return s.stdinIsTTY }
+func (s *IOStreams) IsStdoutTTY() bool { return s.stdoutIsTTY }
+func (s *IOStreams) IsStderrTTY() bool { return s.stderrIsTTY }
+
+func (s *IOStreams) SetStdinTTY(v bool)  { s.stdinIsTTY = v }
+func (s *IOStreams) SetStdoutTTY(v bool) { s.stdoutIsTTY = v }
+func (s *IOStreams) SetStderrTTY(v bool) { s.stderrIsTTY = v }
+
+func isTerminal(f *os.File) bool {
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}

--- a/pkg/iostreams/iostreams_test.go
+++ b/pkg/iostreams/iostreams_test.go
@@ -1,0 +1,51 @@
+package iostreams
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTest_ReturnsWorkingStreams(t *testing.T) {
+	ios, stdin, stdout, stderr := Test()
+
+	stdin.WriteString("input data")
+	assert.NotNil(t, ios)
+	assert.Equal(t, "input data", stdin.String())
+	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "", stderr.String())
+	assert.False(t, ios.IsStdoutTTY())
+	assert.False(t, ios.IsStdinTTY())
+}
+
+func TestIOStreams_SetAndGetTTY(t *testing.T) {
+	ios, _, _, _ := Test()
+
+	ios.SetStdoutTTY(true)
+	assert.True(t, ios.IsStdoutTTY())
+
+	ios.SetStdoutTTY(false)
+	assert.False(t, ios.IsStdoutTTY())
+
+	ios.SetStdinTTY(true)
+	assert.True(t, ios.IsStdinTTY())
+
+	ios.SetStderrTTY(true)
+	assert.True(t, ios.IsStderrTTY())
+}
+
+func TestTest_WriteToOut(t *testing.T) {
+	ios, _, stdout, _ := Test()
+
+	_, err := ios.Out.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", stdout.String())
+}
+
+func TestTest_WriteToErrOut(t *testing.T) {
+	ios, _, _, stderr := Test()
+
+	_, err := ios.ErrOut.Write([]byte("error msg"))
+	assert.NoError(t, err)
+	assert.Equal(t, "error msg", stderr.String())
+}


### PR DESCRIPTION
## Summary
- `pkg/iostreams/iostreams.go` — IOStreams struct with TTY detection, `System()` and `Test()` factories
- `pkg/iostreams/iostreams_test.go` — 4 tests covering stream creation, TTY getters/setters, write to Out/ErrOut

## Test plan
- [x] `TestTest_ReturnsWorkingStreams` — PASS
- [x] `TestIOStreams_SetAndGetTTY` — PASS
- [x] `TestTest_WriteToOut` — PASS
- [x] `TestTest_WriteToErrOut` — PASS
- [x] All tests verified in devcontainer
- [x] CI green

Closes #2