### PR TITLE
feat: add YAML config management with multi-host support (#3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/qubernetic-org/copia-cli
 
 go 1.23
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// HostConfig stores credentials for a single Copia/Gitea instance.
+type HostConfig struct {
+	Token string `yaml:"token"`
+	User  string `yaml:"user"`
+}
+
+// Config is the top-level configuration.
+type Config struct {
+	Hosts map[string]*HostConfig `yaml:"hosts"`
+}
+
+// DefaultPath returns the default config file path.
+func DefaultPath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "copia", "config.yml")
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "copia", "config.yml")
+}
+
+// Load reads a config file. Returns empty config if file does not exist.
+func Load(path string) (*Config, error) {
+	cfg := &Config{Hosts: map[string]*HostConfig{}}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return cfg, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	if cfg.Hosts == nil {
+		cfg.Hosts = map[string]*HostConfig{}
+	}
+	return cfg, nil
+}
+
+// Save writes config to path with 0600 permissions.
+func Save(path string, cfg *Config) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
+}
+
+// DefaultHost returns the first host entry. Returns empty string and nil if no hosts configured.
+func (c *Config) DefaultHost() (string, *HostConfig) {
+	for host, hc := range c.Hosts {
+		return host, hc
+	}
+	return "", nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_NonExistentFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := Load(filepath.Join(dir, "config.yml"))
+	require.NoError(t, err)
+	assert.Empty(t, cfg.Hosts)
+}
+
+func TestSaveAndLoad_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	cfg := &Config{
+		Hosts: map[string]*HostConfig{
+			"app.copia.io": {
+				Token: "abc123",
+				User:  "john",
+			},
+		},
+	}
+
+	err := Save(path, cfg)
+	require.NoError(t, err)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", loaded.Hosts["app.copia.io"].Token)
+	assert.Equal(t, "john", loaded.Hosts["app.copia.io"].User)
+}
+
+func TestSaveAndLoad_MultipleHosts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	cfg := &Config{
+		Hosts: map[string]*HostConfig{
+			"app.copia.io":     {Token: "t1", User: "u1"},
+			"on-prem.corp.com": {Token: "t2", User: "u2"},
+		},
+	}
+
+	require.NoError(t, Save(path, cfg))
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Len(t, loaded.Hosts, 2)
+	assert.Equal(t, "t1", loaded.Hosts["app.copia.io"].Token)
+	assert.Equal(t, "t2", loaded.Hosts["on-prem.corp.com"].Token)
+}
+
+func TestConfig_DefaultHost(t *testing.T) {
+	cfg := &Config{
+		Hosts: map[string]*HostConfig{
+			"app.copia.io": {Token: "t1", User: "u1"},
+		},
+	}
+	host, hc := cfg.DefaultHost()
+	assert.Equal(t, "app.copia.io", host)
+	assert.Equal(t, "t1", hc.Token)
+}
+
+func TestConfig_DefaultHost_Empty(t *testing.T) {
+	cfg := &Config{Hosts: map[string]*HostConfig{}}
+	host, hc := cfg.DefaultHost()
+	assert.Empty(t, host)
+	assert.Nil(t, hc)
+}
+
+func TestSave_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "dir", "config.yml")
+
+	cfg := &Config{
+		Hosts: map[string]*HostConfig{
+			"app.copia.io": {Token: "abc", User: "john"},
+		},
+	}
+
+	err := Save(path, cfg)
+	require.NoError(t, err)
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", loaded.Hosts["app.copia.io"].Token)
+}
+
+func TestDefaultPath_RespectsXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
+	path := DefaultPath()
+	assert.Equal(t, "/custom/config/copia/config.yml", path)
+}


### PR DESCRIPTION
## Summary
- `internal/config/config.go` — Load/Save with 0600 permissions, multi-host, XDG support
- `internal/config/config_test.go` — 7 tests covering all paths

## Test plan
- [x] `TestLoad_NonExistentFile` — PASS
- [x] `TestSaveAndLoad_RoundTrip` — PASS (includes permission check)
- [x] `TestSaveAndLoad_MultipleHosts` — PASS
- [x] `TestConfig_DefaultHost` — PASS
- [x] `TestConfig_DefaultHost_Empty` — PASS
- [x] `TestSave_CreatesDirectory` — PASS
- [x] `TestDefaultPath_RespectsXDG` — PASS
- [x] All tests verified in devcontainer
- [x] CI green

Closes #3