### PR TITLE
feat: add HTTP mock registry for testing (#4)

### DIFF
--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -1,0 +1,81 @@
+package httpmock
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Matcher checks whether an HTTP request matches a stub.
+type Matcher func(req *http.Request) bool
+
+// Responder produces a response for a matched request.
+type Responder func(req *http.Request) (*http.Response, error)
+
+type stub struct {
+	matcher Matcher
+	respond Responder
+	called  bool
+}
+
+// Registry is an http.RoundTripper that returns stubbed responses.
+type Registry struct {
+	mu    sync.Mutex
+	stubs []*stub
+}
+
+// Register adds a matcher/responder pair.
+func (r *Registry) Register(m Matcher, resp Responder) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stubs = append(r.stubs, &stub{matcher: m, respond: resp})
+}
+
+// RoundTrip implements http.RoundTripper.
+func (r *Registry) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, s := range r.stubs {
+		if s.matcher(req) {
+			s.called = true
+			return s.respond(req)
+		}
+	}
+	return nil, fmt.Errorf("no mock matched for %s %s", req.Method, req.URL.Path)
+}
+
+// Verify asserts all registered stubs were called.
+func (r *Registry) Verify(t *testing.T) {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, s := range r.stubs {
+		if !s.called {
+			t.Errorf("httpmock: registered stub was not called")
+		}
+	}
+}
+
+// REST returns a matcher for a REST API call by method and path suffix.
+func REST(method, pathSuffix string) Matcher {
+	return func(req *http.Request) bool {
+		return req.Method == method && strings.HasSuffix(req.URL.Path, pathSuffix)
+	}
+}
+
+// StringResponse returns a responder that sends a fixed status and body.
+func StringResponse(status int, body string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+		}, nil
+	}
+}

--- a/pkg/httpmock/registry_test.go
+++ b/pkg/httpmock/registry_test.go
@@ -1,0 +1,92 @@
+package httpmock
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_MatchesAndResponds(t *testing.T) {
+	reg := &Registry{}
+
+	reg.Register(
+		REST("GET", "/api/v1/repos/owner/repo"),
+		StringResponse(http.StatusOK, `{"name":"repo"}`),
+	)
+
+	req, _ := http.NewRequest("GET", "https://app.copia.io/api/v1/repos/owner/repo", nil)
+	resp, err := reg.RoundTrip(req)
+	require.NoError(t, err)
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.JSONEq(t, `{"name":"repo"}`, string(body))
+}
+
+func TestRegistry_NoMatch_ReturnsError(t *testing.T) {
+	reg := &Registry{}
+
+	req, _ := http.NewRequest("GET", "https://app.copia.io/api/v1/unknown", nil)
+	_, err := reg.RoundTrip(req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no mock matched")
+}
+
+func TestRegistry_MultipleStubs(t *testing.T) {
+	reg := &Registry{}
+
+	reg.Register(
+		REST("GET", "/api/v1/user"),
+		StringResponse(http.StatusOK, `{"login":"john"}`),
+	)
+	reg.Register(
+		REST("POST", "/api/v1/repos"),
+		StringResponse(http.StatusCreated, `{"id":1}`),
+	)
+
+	req1, _ := http.NewRequest("GET", "https://app.copia.io/api/v1/user", nil)
+	resp1, err := reg.RoundTrip(req1)
+	require.NoError(t, err)
+	body1, _ := io.ReadAll(resp1.Body)
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
+	assert.Contains(t, string(body1), "john")
+
+	req2, _ := http.NewRequest("POST", "https://app.copia.io/api/v1/repos", nil)
+	resp2, err := reg.RoundTrip(req2)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp2.StatusCode)
+}
+
+func TestRegistry_Verify_AllCalled(t *testing.T) {
+	fakeT := &testing.T{}
+	reg := &Registry{}
+
+	reg.Register(
+		REST("GET", "/api/v1/user"),
+		StringResponse(http.StatusOK, `{}`),
+	)
+
+	// Call the stub
+	req, _ := http.NewRequest("GET", "https://app.copia.io/api/v1/user", nil)
+	_, _ = reg.RoundTrip(req)
+
+	// Should not fail — stub was called
+	reg.Verify(fakeT)
+	assert.False(t, fakeT.Failed())
+}
+
+func TestRegistry_MethodMismatch(t *testing.T) {
+	reg := &Registry{}
+
+	reg.Register(
+		REST("POST", "/api/v1/user"),
+		StringResponse(http.StatusOK, `{}`),
+	)
+
+	req, _ := http.NewRequest("GET", "https://app.copia.io/api/v1/user", nil)
+	_, err := reg.RoundTrip(req)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- `pkg/httpmock/registry.go` — Registry (RoundTripper), REST matcher, StringResponse, Verify
- `pkg/httpmock/registry_test.go` — 5 tests

## Test plan
- [x] `TestRegistry_MatchesAndResponds` — PASS
- [x] `TestRegistry_NoMatch_ReturnsError` — PASS
- [x] `TestRegistry_MultipleStubs` — PASS
- [x] `TestRegistry_Verify_AllCalled` — PASS
- [x] `TestRegistry_MethodMismatch` — PASS
- [x] All tests verified in devcontainer
- [x] CI green

Closes #4