### PR TITLE
feat: add Claude Code CLI to devcontainer (#33)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,9 @@
       "version": "lts"
     }
   },
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
+  ],
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
- Add Node.js LTS devcontainer feature
- Install Claude Code CLI via npm in postCreateCommand
- Bind mount host ~/.claude/ into container for full config (skills, plugins, memory, credentials)

## Test plan
- [x] Devcontainer builds successfully
- [x] `claude --version` works inside container
- [x] Skills, plugins, memory visible inside container
- [x] `go version`, `gh --version`, `golangci-lint --version` still work
- [x] CI green

Closes #33