### PR TITLE
test: add integration tests against live Copia API (#40)

### DIFF
--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuth_ValidateToken(t *testing.T) {
+	env := loadTestEnv(t)
+
+	url := fmt.Sprintf("https://%s/api/v1/user", env.Host)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "token "+env.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var user struct {
+		Login string `json:"login"`
+		ID    int64  `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(body, &user))
+	assert.NotEmpty(t, user.Login)
+	assert.Greater(t, user.ID, int64(0))
+
+	t.Logf("Authenticated as: %s (ID: %d)", user.Login, user.ID)
+}
+
+func TestAuth_InvalidToken(t *testing.T) {
+	env := loadTestEnv(t)
+
+	url := fmt.Sprintf("https://%s/api/v1/user", env.Host)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "token invalid-token-that-does-not-exist")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// Copia/Gitea returns 403 for invalid tokens (not 401)
+	assert.Contains(t, []int{http.StatusUnauthorized, http.StatusForbidden}, resp.StatusCode)
+}

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -1,0 +1,35 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"testing"
+)
+
+type testEnv struct {
+	Host  string
+	Token string
+	Owner string
+	Repo  string
+}
+
+func loadTestEnv(t *testing.T) testEnv {
+	t.Helper()
+
+	host := os.Getenv("COPIA_TEST_HOST")
+	token := os.Getenv("COPIA_TEST_TOKEN")
+	owner := os.Getenv("COPIA_TEST_OWNER")
+	repo := os.Getenv("COPIA_TEST_REPO")
+
+	if host == "" || token == "" || owner == "" || repo == "" {
+		t.Skip("Integration test env vars not set (COPIA_TEST_HOST, COPIA_TEST_TOKEN, COPIA_TEST_OWNER, COPIA_TEST_REPO)")
+	}
+
+	return testEnv{
+		Host:  host,
+		Token: token,
+		Owner: owner,
+		Repo:  repo,
+	}
+}

--- a/test/integration/issue_test.go
+++ b/test/integration/issue_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue_FullLifecycle(t *testing.T) {
+	env := loadTestEnv(t)
+	baseURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues", env.Host, env.Owner, env.Repo)
+
+	// Create issue
+	createPayload, _ := json.Marshal(map[string]string{
+		"title": "[integration-test] lifecycle test",
+		"body":  "Created by integration test. Will be closed automatically.",
+	})
+
+	createReq, err := http.NewRequest("POST", baseURL, bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "token "+env.Token)
+	createReq.Header.Set("Content-Type", "application/json")
+
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	defer func() { _ = createResp.Body.Close() }()
+
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	createBody, err := io.ReadAll(createResp.Body)
+	require.NoError(t, err)
+
+	var created struct {
+		Number int64  `json:"number"`
+		Title  string `json:"title"`
+		State  string `json:"state"`
+	}
+	require.NoError(t, json.Unmarshal(createBody, &created))
+	assert.Equal(t, "[integration-test] lifecycle test", created.Title)
+	assert.Equal(t, "open", created.State)
+
+	t.Logf("Created issue #%d", created.Number)
+
+	// Cleanup: close issue at end
+	defer func() {
+		closePayload, _ := json.Marshal(map[string]string{"state": "closed"})
+		closeURL := fmt.Sprintf("%s/%d", baseURL, created.Number)
+		closeReq, err := http.NewRequest("PATCH", closeURL, bytes.NewReader(closePayload))
+		if err != nil {
+			t.Logf("Failed to create close request: %v", err)
+			return
+		}
+		closeReq.Header.Set("Authorization", "token "+env.Token)
+		closeReq.Header.Set("Content-Type", "application/json")
+
+		closeResp, err := http.DefaultClient.Do(closeReq)
+		if err != nil {
+			t.Logf("Failed to close issue: %v", err)
+			return
+		}
+		_ = closeResp.Body.Close()
+		t.Logf("Closed issue #%d (HTTP %d)", created.Number, closeResp.StatusCode)
+	}()
+
+	// View issue
+	viewURL := fmt.Sprintf("%s/%d", baseURL, created.Number)
+	viewReq, err := http.NewRequest("GET", viewURL, nil)
+	require.NoError(t, err)
+	viewReq.Header.Set("Authorization", "token "+env.Token)
+
+	viewResp, err := http.DefaultClient.Do(viewReq)
+	require.NoError(t, err)
+	defer func() { _ = viewResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, viewResp.StatusCode)
+
+	viewBody, err := io.ReadAll(viewResp.Body)
+	require.NoError(t, err)
+
+	var viewed struct {
+		Number int64  `json:"number"`
+		Title  string `json:"title"`
+	}
+	require.NoError(t, json.Unmarshal(viewBody, &viewed))
+	assert.Equal(t, created.Number, viewed.Number)
+
+	// Add comment
+	commentPayload, _ := json.Marshal(map[string]string{
+		"body": "Integration test comment — will be cleaned up.",
+	})
+	commentURL := fmt.Sprintf("%s/%d/comments", baseURL, created.Number)
+	commentReq, err := http.NewRequest("POST", commentURL, bytes.NewReader(commentPayload))
+	require.NoError(t, err)
+	commentReq.Header.Set("Authorization", "token "+env.Token)
+	commentReq.Header.Set("Content-Type", "application/json")
+
+	commentResp, err := http.DefaultClient.Do(commentReq)
+	require.NoError(t, err)
+	defer func() { _ = commentResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusCreated, commentResp.StatusCode)
+
+	t.Logf("Added comment to issue #%d", created.Number)
+}
+
+func TestIssue_List(t *testing.T) {
+	env := loadTestEnv(t)
+
+	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=all&limit=5&type=issues",
+		env.Host, env.Owner, env.Repo)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "token "+env.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var issues []struct {
+		Number int64 `json:"number"`
+	}
+	require.NoError(t, json.Unmarshal(body, &issues))
+
+	t.Logf("Found %d issues", len(issues))
+}

--- a/test/integration/label_test.go
+++ b/test/integration/label_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLabel_CreateListDelete(t *testing.T) {
+	env := loadTestEnv(t)
+	baseURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/labels", env.Host, env.Owner, env.Repo)
+
+	// Create label
+	createPayload, _ := json.Marshal(map[string]string{
+		"name":        "integration-test-label",
+		"color":       "#ff0000",
+		"description": "Created by integration test",
+	})
+
+	createReq, err := http.NewRequest("POST", baseURL, bytes.NewReader(createPayload))
+	require.NoError(t, err)
+	createReq.Header.Set("Authorization", "token "+env.Token)
+	createReq.Header.Set("Content-Type", "application/json")
+
+	createResp, err := http.DefaultClient.Do(createReq)
+	require.NoError(t, err)
+	defer func() { _ = createResp.Body.Close() }()
+
+	require.Equal(t, http.StatusCreated, createResp.StatusCode)
+
+	createBody, err := io.ReadAll(createResp.Body)
+	require.NoError(t, err)
+
+	var created struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal(createBody, &created))
+	assert.Equal(t, "integration-test-label", created.Name)
+	assert.Greater(t, created.ID, int64(0))
+
+	t.Logf("Created label: %s (ID: %d)", created.Name, created.ID)
+
+	// Cleanup: delete label
+	defer func() {
+		deleteURL := fmt.Sprintf("%s/%d", baseURL, created.ID)
+		deleteReq, err := http.NewRequest("DELETE", deleteURL, nil)
+		if err != nil {
+			t.Logf("Failed to create delete request: %v", err)
+			return
+		}
+		deleteReq.Header.Set("Authorization", "token "+env.Token)
+
+		deleteResp, err := http.DefaultClient.Do(deleteReq)
+		if err != nil {
+			t.Logf("Failed to delete label: %v", err)
+			return
+		}
+		_ = deleteResp.Body.Close()
+		t.Logf("Deleted label ID: %d (HTTP %d)", created.ID, deleteResp.StatusCode)
+	}()
+
+	// List labels and verify our label exists
+	listReq, err := http.NewRequest("GET", baseURL, nil)
+	require.NoError(t, err)
+	listReq.Header.Set("Authorization", "token "+env.Token)
+
+	listResp, err := http.DefaultClient.Do(listReq)
+	require.NoError(t, err)
+	defer func() { _ = listResp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, listResp.StatusCode)
+
+	listBody, err := io.ReadAll(listResp.Body)
+	require.NoError(t, err)
+
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal(listBody, &labels))
+
+	found := false
+	for _, l := range labels {
+		if l.Name == "integration-test-label" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "created label not found in list")
+}

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPR_List(t *testing.T) {
+	env := loadTestEnv(t)
+
+	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls?state=all&limit=5",
+		env.Host, env.Owner, env.Repo)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "token "+env.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var prs []struct {
+		Number int64 `json:"number"`
+	}
+	require.NoError(t, json.Unmarshal(body, &prs))
+
+	t.Logf("Found %d pull requests", len(prs))
+}

--- a/test/integration/repo_test.go
+++ b/test/integration/repo_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepo_ListUserRepos(t *testing.T) {
+	env := loadTestEnv(t)
+
+	url := fmt.Sprintf("https://%s/api/v1/user/repos?limit=5", env.Host)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "token "+env.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var repos []struct {
+		FullName string `json:"full_name"`
+	}
+	require.NoError(t, json.Unmarshal(body, &repos))
+	assert.NotEmpty(t, repos)
+
+	t.Logf("Found %d repos", len(repos))
+}
+
+func TestRepo_ViewTestRepo(t *testing.T) {
+	env := loadTestEnv(t)
+
+	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s", env.Host, env.Owner, env.Repo)
+	req, err := http.NewRequest("GET", url, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "token "+env.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var repo struct {
+		FullName      string `json:"full_name"`
+		DefaultBranch string `json:"default_branch"`
+	}
+	require.NoError(t, json.Unmarshal(body, &repo))
+	assert.Contains(t, repo.FullName, env.Repo)
+	assert.NotEmpty(t, repo.DefaultBranch)
+
+	t.Logf("Repo: %s (default branch: %s)", repo.FullName, repo.DefaultBranch)
+}


### PR DESCRIPTION
## Summary
8 integration tests against app.copia.io using dedicated test repo:
- Auth: token validation, invalid token (403)
- Repo: list user repos, view test repo
- Label: create → list → delete lifecycle
- Issue: create → view → comment → close lifecycle, list
- PR: list

All tests use `//go:build integration`, read from env vars, clean up after themselves.

## Test plan
- [x] `TestAuth_ValidateToken` — PASS
- [x] `TestAuth_InvalidToken` — PASS
- [x] `TestRepo_ListUserRepos` — PASS
- [x] `TestRepo_ViewTestRepo` — PASS
- [x] `TestLabel_CreateListDelete` — PASS
- [x] `TestIssue_FullLifecycle` — PASS
- [x] `TestIssue_List` — PASS
- [x] `TestPR_List` — PASS
- [x] Unit tests still pass (`make test`)
- [x] All verified in devcontainer
- [x] CI green

Closes #40