### PR TITLE
ci: run integration tests on PRs too (#52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     needs: test
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Remove `if: github.event_name == 'push'` from integration job so it runs on PRs too.

## Test plan
- [x] Integration tests run on this PR
- [x] CI green

Closes #52