### PR TITLE
feat: add copia issue edit (#16)

### DIFF
--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -1,0 +1,177 @@
+package edit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+)
+
+type EditOptions struct {
+	IO         *iostreams.IOStreams
+	HTTPClient *http.Client
+	Host       string
+	Token      string
+	Owner      string
+	Repo       string
+	Number     int64
+	Title      string
+	Body       string
+	AddLabels  []string
+	Assignees  []string
+	Milestone  int64
+}
+
+func NewCmdEdit(f *cmdutil.Factory) *cobra.Command {
+	opts := &EditOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "edit <number>",
+		Short: "Edit an issue",
+		Example: `  copia issue edit 12 --title "New title"
+  copia issue edit 12 --add-label bug --add-label urgent
+  copia issue edit 12 --assignee john --assignee jane
+  copia issue edit 12 --milestone 1`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			num, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid issue number: %s", args[0])
+			}
+			opts.Number = num
+			opts.IO = f.IOStreams
+
+			host, token, err := f.ResolveAuth()
+			if err != nil {
+				return err
+			}
+			opts.Host = host
+			opts.Token = token
+
+			if f.BaseRepo == nil {
+				return fmt.Errorf("could not determine repository. Use --repo flag")
+			}
+			owner, repo, err := f.BaseRepo()
+			if err != nil {
+				return err
+			}
+			opts.Owner = owner
+			opts.Repo = repo
+			opts.HTTPClient = &http.Client{}
+			return editRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Title, "title", "t", "", "Set title")
+	cmd.Flags().StringVarP(&opts.Body, "body", "b", "", "Set body")
+	cmd.Flags().StringSliceVar(&opts.AddLabels, "add-label", nil, "Add labels")
+	cmd.Flags().StringSliceVarP(&opts.Assignees, "assignee", "a", nil, "Set assignees")
+	cmd.Flags().Int64VarP(&opts.Milestone, "milestone", "m", 0, "Set milestone ID")
+
+	return cmd
+}
+
+func editRun(opts *EditOptions) error {
+	hasIssueUpdate := opts.Title != "" || opts.Body != "" || len(opts.Assignees) > 0 || opts.Milestone > 0
+	hasLabelAdd := len(opts.AddLabels) > 0
+
+	if !hasIssueUpdate && !hasLabelAdd {
+		return fmt.Errorf("nothing to edit. Use --title, --body, --add-label, --assignee, or --milestone")
+	}
+
+	if hasLabelAdd {
+		if err := addLabels(opts); err != nil {
+			return err
+		}
+	}
+
+	if hasIssueUpdate {
+		if err := updateIssue(opts); err != nil {
+			return err
+		}
+	}
+
+	_, _ = fmt.Fprintf(opts.IO.Out, "Updated issue #%d\n", opts.Number)
+	return nil
+}
+
+func updateIssue(opts *EditOptions) error {
+	payload := map[string]interface{}{}
+	if opts.Title != "" {
+		payload["title"] = opts.Title
+	}
+	if opts.Body != "" {
+		payload["body"] = opts.Body
+	}
+	if len(opts.Assignees) > 0 {
+		payload["assignees"] = opts.Assignees
+	}
+	if opts.Milestone > 0 {
+		payload["milestone"] = opts.Milestone
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d",
+		opts.Host, opts.Owner, opts.Repo, opts.Number)
+
+	req, err := http.NewRequest("PATCH", url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+opts.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to update issue (HTTP %d)", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func addLabels(opts *EditOptions) error {
+	payload := map[string]interface{}{
+		"labels": opts.AddLabels,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d/labels",
+		opts.Host, opts.Owner, opts.Repo, opts.Number)
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+opts.Token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to add labels (HTTP %d)", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -1,0 +1,132 @@
+package edit
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/qubernetic-org/copia-cli/pkg/httpmock"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditRun_SetTitle(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("PATCH", "/api/v1/repos/my-org/my-repo/issues/12"),
+		httpmock.StringResponse(http.StatusOK, `{"number":12,"title":"Updated title"}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &EditOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "my-repo",
+		Number:     12,
+		Title:      "Updated title",
+	}
+
+	err := editRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Updated issue #12")
+}
+
+func TestEditRun_AddLabels(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("POST", "/api/v1/repos/my-org/my-repo/issues/12/labels"),
+		httpmock.StringResponse(http.StatusOK, `[{"id":1,"name":"bug"}]`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &EditOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "my-repo",
+		Number:     12,
+		AddLabels:  []string{"bug"},
+	}
+
+	err := editRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Updated issue #12")
+}
+
+func TestEditRun_SetAssignees(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("PATCH", "/api/v1/repos/my-org/my-repo/issues/12"),
+		httpmock.StringResponse(http.StatusOK, `{"number":12}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &EditOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "my-repo",
+		Number:     12,
+		Assignees:  []string{"john", "jane"},
+	}
+
+	err := editRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Updated issue #12")
+}
+
+func TestEditRun_SetMilestone(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("PATCH", "/api/v1/repos/my-org/my-repo/issues/12"),
+		httpmock.StringResponse(http.StatusOK, `{"number":12}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &EditOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "my-repo",
+		Number:     12,
+		Milestone:  1,
+	}
+
+	err := editRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Updated issue #12")
+}
+
+func TestEditRun_NothingToEdit(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &EditOptions{
+		IO:     ios,
+		Number: 12,
+	}
+
+	err := editRun(opts)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing to edit")
+}

--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -5,6 +5,7 @@ import (
 	closeCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue/close"
 	commentCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue/comment"
 	createCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue/create"
+	editCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue/edit"
 	listCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue/list"
 	viewCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue/view"
 	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
@@ -23,6 +24,7 @@ func NewCmdIssue(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(viewCmd.NewCmdView(f))
 	cmd.AddCommand(closeCmd.NewCmdClose(f))
 	cmd.AddCommand(commentCmd.NewCmdComment(f))
+	cmd.AddCommand(editCmd.NewCmdEdit(f))
 
 	return cmd
 }


### PR DESCRIPTION
## Summary
- `pkg/cmd/issue/edit/` — Edit issue metadata (title, body, labels, assignees, milestone)
- Registered in issue parent command (now 6 subcommands)

## Test plan
- [x] `TestEditRun_SetTitle` — PASS
- [x] `TestEditRun_AddLabels` — PASS
- [x] `TestEditRun_SetAssignees` — PASS
- [x] `TestEditRun_SetMilestone` — PASS
- [x] `TestEditRun_NothingToEdit` — PASS
- [x] All tests verified in devcontainer
- [x] CI green

Closes #16