### PR TITLE
feat: add Homebrew tap distribution (#17)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,5 +39,17 @@ release:
 checksum:
   name_template: "checksums.txt"
 
+brews:
+  - repository:
+      owner: qubernetic-org
+      name: homebrew-tap
+    homepage: "https://github.com/qubernetic-org/copia-cli"
+    description: "CLI for Copia — source control for industrial automation"
+    license: "MIT"
+    install: |
+      bin.install "copia"
+    test: |
+      system "#{bin}/copia", "--version"
+
 changelog:
   use: github-native

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The official Copia Desktop app handles `clone` and `open`. That's it. There is n
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew install qubernetic-org/tap/copia
+```
+
 ### Precompiled Binaries
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/qubernetic-org/copia-cli/releases/latest).


### PR DESCRIPTION
## Summary
- Created `qubernetic-org/homebrew-tap` repository
- Added `brews` section to `.goreleaser.yml`
- Added Homebrew install instructions to README

## Test plan
- [x] `qubernetic-org/homebrew-tap` repo exists
- [x] GoReleaser config valid (brews section)
- [x] README updated with `brew install` instructions
- [x] CI green

Closes #17