### PR TITLE
feat: add copia api generic REST escape hatch (#20)

### DIFF
--- a/internal/copiacmd/root.go
+++ b/internal/copiacmd/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/qubernetic-org/copia-cli/internal/build"
 	"github.com/qubernetic-org/copia-cli/internal/config"
+	apiCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/api"
 	authCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/auth"
 	issueCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/issue"
 	labelCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/label"
@@ -39,6 +40,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(labelCmd.NewCmdLabel(f))
 	cmd.AddCommand(prCmd.NewCmdPR(f))
 	cmd.AddCommand(releaseCmd.NewCmdRelease(f))
+	cmd.AddCommand(apiCmd.NewCmdApi(f))
 
 	return cmd
 }

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+)
+
+// ApiOptions holds all inputs for the api command.
+type ApiOptions struct {
+	IO         *iostreams.IOStreams
+	HTTPClient *http.Client
+	Host       string
+	Token      string
+	Method     string
+	Path       string
+	Fields     []string
+	Headers    []string
+}
+
+// NewCmdApi creates the `copia api` command.
+func NewCmdApi(f *cmdutil.Factory) *cobra.Command {
+	opts := &ApiOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "api <path>",
+		Short: "Make an API request",
+		Long:  "Make an authenticated request to the Copia/Gitea REST API.",
+		Example: `  # Get authenticated user
+  copia api /user
+
+  # Create an issue
+  copia api -X POST /repos/my-org/my-repo/issues --field title="Bug report"
+
+  # Delete a repo
+  copia api -X DELETE /repos/my-org/old-repo
+
+  # Custom header
+  copia api /user --header "Accept: application/json"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Path = args[0]
+			opts.IO = f.IOStreams
+
+			host, token, err := f.ResolveAuth()
+			if err != nil {
+				return err
+			}
+			opts.Host = host
+			opts.Token = token
+			opts.HTTPClient = &http.Client{}
+			return apiRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Method, "method", "X", "", "HTTP method (default: GET, or POST if --field is used)")
+	cmd.Flags().StringSliceVarP(&opts.Fields, "field", "f", nil, "Add JSON body field (key=value)")
+	cmd.Flags().StringSliceVarP(&opts.Headers, "header", "H", nil, "Add HTTP header (key: value)")
+
+	return cmd
+}
+
+func apiRun(opts *ApiOptions) error {
+	if opts.Path == "" {
+		return fmt.Errorf("path required")
+	}
+
+	// Normalize path
+	path := opts.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if !strings.HasPrefix(path, "/api/v1") {
+		path = "/api/v1" + path
+	}
+
+	// Determine method
+	method := opts.Method
+	if method == "" {
+		if len(opts.Fields) > 0 {
+			method = "POST"
+		} else {
+			method = "GET"
+		}
+	}
+
+	// Build body from fields
+	var body io.Reader
+	if len(opts.Fields) > 0 {
+		payload := map[string]string{}
+		for _, f := range opts.Fields {
+			parts := strings.SplitN(f, "=", 2)
+			if len(parts) == 2 {
+				payload[parts[0]] = parts[1]
+			}
+		}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+
+	url := fmt.Sprintf("https://%s%s", opts.Host, path)
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+opts.Token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Custom headers
+	for _, h := range opts.Headers {
+		parts := strings.SplitN(h, ":", 2)
+		if len(parts) == 2 {
+			req.Header.Set(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+		}
+	}
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// Pretty-print JSON if possible
+	var prettyJSON bytes.Buffer
+	if json.Indent(&prettyJSON, respBody, "", "  ") == nil {
+		_, _ = fmt.Fprintln(opts.IO.Out, prettyJSON.String())
+	} else {
+		_, _ = fmt.Fprintln(opts.IO.Out, string(respBody))
+	}
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/qubernetic-org/copia-cli/pkg/httpmock"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApiRun_GET(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/user"),
+		httpmock.StringResponse(http.StatusOK, `{"login":"john","id":1}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &ApiOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Method:     "GET",
+		Path:       "/user",
+	}
+
+	err := apiRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "john")
+}
+
+func TestApiRun_POST_WithFields(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("POST", "/api/v1/repos/my-org/my-repo/issues"),
+		httpmock.StringResponse(http.StatusCreated, `{"number":1,"title":"test issue"}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &ApiOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Method:     "POST",
+		Path:       "/repos/my-org/my-repo/issues",
+		Fields:     []string{"title=test issue", "body=description"},
+	}
+
+	err := apiRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "test issue")
+}
+
+func TestApiRun_DELETE(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("DELETE", "/api/v1/repos/my-org/my-repo"),
+		httpmock.StringResponse(http.StatusNoContent, ``),
+	)
+
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &ApiOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Method:     "DELETE",
+		Path:       "/repos/my-org/my-repo",
+	}
+
+	err := apiRun(opts)
+	require.NoError(t, err)
+}
+
+func TestApiRun_DefaultMethodGET(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/version"),
+		httpmock.StringResponse(http.StatusOK, `{"version":"1.21.0"}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &ApiOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Path:       "/version",
+	}
+
+	err := apiRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "1.21.0")
+}
+
+func TestApiRun_MissingPath(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &ApiOptions{IO: ios, Path: ""}
+
+	err := apiRun(opts)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "path required")
+}


### PR DESCRIPTION
## Summary
- `pkg/cmd/api/api.go` — Generic REST client with -X method, --field, --header
- Auto-prefixes /api/v1, pretty-prints JSON, handles 204 No Content
- Registered in root command

## Test plan
- [x] `TestApiRun_GET` — PASS
- [x] `TestApiRun_POST_WithFields` — PASS
- [x] `TestApiRun_DELETE` — PASS
- [x] `TestApiRun_DefaultMethodGET` — PASS
- [x] `TestApiRun_MissingPath` — PASS
- [x] All tests verified in devcontainer
- [x] CI green

Closes #20