### PR TITLE
feat: add copia search commands (repos, issues) (#21)

### DIFF
--- a/internal/copiacmd/root.go
+++ b/internal/copiacmd/root.go
@@ -12,6 +12,7 @@ import (
 	labelCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/label"
 	prCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/pr"
 	releaseCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/release"
+	searchCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/search"
 	repoCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/repo"
 	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
 	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
@@ -41,6 +42,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(prCmd.NewCmdPR(f))
 	cmd.AddCommand(releaseCmd.NewCmdRelease(f))
 	cmd.AddCommand(apiCmd.NewCmdApi(f))
+	cmd.AddCommand(searchCmd.NewCmdSearch(f))
 
 	return cmd
 }

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -1,0 +1,111 @@
+package issues
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+)
+
+type SearchOptions struct {
+	IO         *iostreams.IOStreams
+	HTTPClient *http.Client
+	Host       string
+	Token      string
+	Query      string
+	State      string
+	Limit      int
+	JSON       cmdutil.JSONFlags
+}
+
+type repoRef struct {
+	FullName string `json:"full_name"`
+}
+
+type issueEntry struct {
+	Number     int64   `json:"number"`
+	Title      string  `json:"title"`
+	State      string  `json:"state"`
+	Repository repoRef `json:"repository"`
+}
+
+func NewCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
+	opts := &SearchOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "issues <query>",
+		Short: "Search issues",
+		Example: `  copia search issues "sensor timeout"
+  copia search issues bug --state closed`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Query = args[0]
+			opts.IO = f.IOStreams
+
+			host, token, err := f.ResolveAuth()
+			if err != nil {
+				return err
+			}
+			opts.Host = host
+			opts.Token = token
+			opts.HTTPClient = &http.Client{}
+			return searchRun(opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.State, "state", "s", "", "Filter by state: {open|closed}")
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of results")
+	cmdutil.AddJSONFlags(cmd, &opts.JSON, []string{"number", "title", "state", "repository"})
+
+	return cmd
+}
+
+func searchRun(opts *SearchOptions) error {
+	u := fmt.Sprintf("https://%s/api/v1/repos/search?q=%s&limit=%d&type=issues",
+		opts.Host, url.QueryEscape(opts.Query), opts.Limit)
+	if opts.State != "" {
+		u += "&state=" + url.QueryEscape(opts.State)
+	}
+
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+opts.Token)
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var issues []issueEntry
+	if err := json.Unmarshal(body, &issues); err != nil {
+		return err
+	}
+
+	if opts.JSON.IsJSON() {
+		return cmdutil.PrintJSON(opts.IO.Out, issues)
+	}
+
+	w := tabwriter.NewWriter(opts.IO.Out, 0, 0, 2, ' ', 0)
+	for _, i := range issues {
+		_, _ = fmt.Fprintf(w, "%s#%d\t%s\t%s\n", i.Repository.FullName, i.Number, i.Title, i.State)
+	}
+	return w.Flush()
+}

--- a/pkg/cmd/search/issues/issues_test.go
+++ b/pkg/cmd/search/issues/issues_test.go
@@ -1,0 +1,40 @@
+package issues
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/qubernetic-org/copia-cli/pkg/httpmock"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchIssues_Success(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/repos/search"),
+		httpmock.StringResponse(http.StatusOK, `[
+			{"number":12,"title":"Fix PLC timeout","state":"open","repository":{"full_name":"my-org/plc"}},
+			{"number":5,"title":"Sensor error","state":"closed","repository":{"full_name":"my-org/plc"}}
+		]`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &SearchOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Query:      "timeout",
+		State:      "open",
+		Limit:      30,
+	}
+
+	err := searchRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Fix PLC timeout")
+}

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -1,0 +1,107 @@
+package repos
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+)
+
+var validJSONFields = []string{"fullName", "description", "htmlUrl"}
+
+type SearchOptions struct {
+	IO         *iostreams.IOStreams
+	HTTPClient *http.Client
+	Host       string
+	Token      string
+	Query      string
+	Limit      int
+	JSON       cmdutil.JSONFlags
+}
+
+type repoEntry struct {
+	FullName    string `json:"full_name"`
+	Description string `json:"description"`
+	HTMLURL     string `json:"html_url"`
+}
+
+type searchResponse struct {
+	Data []repoEntry `json:"data"`
+}
+
+func NewCmdSearchRepos(f *cmdutil.Factory) *cobra.Command {
+	opts := &SearchOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "repos <query>",
+		Short: "Search repositories",
+		Example: `  copia search repos plc
+  copia search repos "automation controller" --json fullName,description`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Query = args[0]
+			opts.IO = f.IOStreams
+
+			host, token, err := f.ResolveAuth()
+			if err != nil {
+				return err
+			}
+			opts.Host = host
+			opts.Token = token
+			opts.HTTPClient = &http.Client{}
+			return searchRun(opts)
+		},
+	}
+
+	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of results")
+	cmdutil.AddJSONFlags(cmd, &opts.JSON, validJSONFields)
+
+	return cmd
+}
+
+func searchRun(opts *SearchOptions) error {
+	u := fmt.Sprintf("https://%s/api/v1/repos/search?q=%s&limit=%d",
+		opts.Host, url.QueryEscape(opts.Query), opts.Limit)
+
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "token "+opts.Token)
+
+	resp, err := opts.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var result searchResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return err
+	}
+
+	if opts.JSON.IsJSON() {
+		return cmdutil.PrintJSON(opts.IO.Out, result.Data)
+	}
+
+	w := tabwriter.NewWriter(opts.IO.Out, 0, 0, 2, ' ', 0)
+	for _, r := range result.Data {
+		_, _ = fmt.Fprintf(w, "%s\t%s\n", r.FullName, r.Description)
+	}
+	return w.Flush()
+}

--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -1,0 +1,68 @@
+package repos
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
+	"github.com/qubernetic-org/copia-cli/pkg/httpmock"
+	"github.com/qubernetic-org/copia-cli/pkg/iostreams"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchRepos_Success(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/repos/search"),
+		httpmock.StringResponse(http.StatusOK, `{"data":[
+			{"full_name":"my-org/plc-project","description":"PLC code","html_url":"https://app.copia.io/my-org/plc-project"},
+			{"full_name":"other/hmi","description":"HMI config","html_url":"https://app.copia.io/other/hmi"}
+		]}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &SearchOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Query:      "plc",
+		Limit:      30,
+	}
+
+	err := searchRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "plc-project")
+}
+
+func TestSearchRepos_JSON(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/repos/search"),
+		httpmock.StringResponse(http.StatusOK, `{"data":[
+			{"full_name":"my-org/plc","description":"PLC","html_url":""}
+		]}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &SearchOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Query:      "plc",
+		Limit:      30,
+		JSON:       cmdutil.JSONFlags{Fields: []string{"fullName"}},
+	}
+
+	err := searchRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), `"full_name"`)
+}

--- a/pkg/cmd/search/search.go
+++ b/pkg/cmd/search/search.go
@@ -1,0 +1,21 @@
+package search
+
+import (
+	"github.com/spf13/cobra"
+	issuesCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/search/issues"
+	reposCmd "github.com/qubernetic-org/copia-cli/pkg/cmd/search/repos"
+	"github.com/qubernetic-org/copia-cli/pkg/cmdutil"
+)
+
+func NewCmdSearch(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "search <command>",
+		Short: "Search across Copia",
+		Long:  "Search repositories and issues.",
+	}
+
+	cmd.AddCommand(reposCmd.NewCmdSearchRepos(f))
+	cmd.AddCommand(issuesCmd.NewCmdSearchIssues(f))
+
+	return cmd
+}


### PR DESCRIPTION
## Summary
- `pkg/cmd/search/repos/` — Search repos via Gitea API
- `pkg/cmd/search/issues/` — Search issues with --state filter
- Both support --json and --limit

## Test plan
- [x] `TestSearchRepos_Success` — PASS
- [x] `TestSearchRepos_JSON` — PASS
- [x] `TestSearchIssues_Success` — PASS
- [x] All tests verified in devcontainer
- [x] CI green

Closes #21