### PR TITLE
feat: add deb/rpm, universal binary, extra arch targets

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,12 +12,30 @@ builds:
     goarch:
       - amd64
       - arm64
+      - "386"
+      - arm
+    goarm:
+      - "6"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     ldflags:
       - -s -w
       - -X github.com/qubernetic/copia-cli/internal/build.Version={{.Version}}
       - -X github.com/qubernetic/copia-cli/internal/build.Date={{time "2006-01-02"}}
     env:
       - CGO_ENABLED=0
+
+universal_binaries:
+  - id: copia-cli-macos
+    ids:
+      - copia-cli
+    replace: true
+    name_template: "copia-cli"
 
 archives:
   - format: tar.gz
@@ -51,6 +69,22 @@ brews:
       bin.install "copia-cli"
     test: |
       system "#{bin}/copia-cli", "--version"
+
+nfpms:
+  - id: copia-cli
+    package_name: copia-cli
+    vendor: Qubernetic
+    homepage: "https://github.com/qubernetic/copia-cli"
+    maintainer: "Qubernetic <hello@qubernetic.io>"
+    description: "CLI for Copia — source control for industrial automation"
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/copia-cli/LICENSE
 
 changelog:
   use: github-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Release variants: .deb, .rpm packages via nfpms
+- macOS universal binary (amd64+arm64 fat binary)
+- linux/386, linux/arm (v6), windows/386 build targets
+
 ## [0.4.0-rc.1] - 2026-04-02
 
 ### Changed


### PR DESCRIPTION
## Summary

Closes #76

- **nfpms**: .deb and .rpm packages for Linux distributions
- **universal_binaries**: macOS fat binary (amd64+arm64) — single download for all Macs
- **Extra architectures**: linux/386, linux/arm (v6), windows/386
- **Ignore invalid combos**: darwin/386, darwin/arm, windows/arm

## Release artifacts after this change

| Platform | Architectures | Formats |
|----------|--------------|---------|
| Linux | amd64, arm64, 386, armv6 | tar.gz, .deb, .rpm |
| macOS | universal (amd64+arm64) | tar.gz |
| Windows | amd64, arm64, 386 | .zip |

## Test plan

- [ ] GoReleaser validates config in release workflow
- [ ] Tag a pre-release and verify all artifacts are generated
- [ ] Verify .deb installs on Ubuntu/Debian
- [ ] Verify .rpm installs on Fedora/RHEL