### PR TITLE
chore(release): prepare v0.5.0-rc.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,12 +12,30 @@ builds:
     goarch:
       - amd64
       - arm64
+      - "386"
+      - arm
+    goarm:
+      - "6"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
     ldflags:
       - -s -w
       - -X github.com/qubernetic/copia-cli/internal/build.Version={{.Version}}
       - -X github.com/qubernetic/copia-cli/internal/build.Date={{time "2006-01-02"}}
     env:
       - CGO_ENABLED=0
+
+universal_binaries:
+  - id: copia-cli-macos
+    ids:
+      - copia-cli
+    replace: true
+    name_template: "copia-cli"
 
 archives:
   - format: tar.gz
@@ -51,6 +69,22 @@ brews:
       bin.install "copia-cli"
     test: |
       system "#{bin}/copia-cli", "--version"
+
+nfpms:
+  - id: copia-cli
+    package_name: copia-cli
+    vendor: Qubernetic
+    homepage: "https://github.com/qubernetic/copia-cli"
+    maintainer: "Qubernetic <hello@qubernetic.io>"
+    description: "CLI for Copia — source control for industrial automation"
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/copia-cli/LICENSE
 
 changelog:
   use: github-native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0-rc.1] - 2026-04-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Release variants: .deb, .rpm packages via nfpms
+- macOS universal binary (amd64+arm64 fat binary)
+- linux/386, linux/arm (v6), windows/386 build targets
+
 ## [0.4.0-rc.1] - 2026-04-02
 
 ### Changed


### PR DESCRIPTION
## Release v0.5.0-rc.1

### Added
- Release variants: .deb, .rpm packages via nfpms
- macOS universal binary (amd64+arm64 fat binary)
- linux/386, linux/arm (v6), windows/386 build targets

Merging to main triggers GoReleaser via release workflow.