### PR TITLE
fix: close response body after reading in auth login (#97)

### DIFF
--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -92,7 +92,7 @@ func loginRun(opts *LoginOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("authentication failed for %s (HTTP %d)", opts.Host, resp.StatusCode)

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -92,7 +92,7 @@ func loginRun(opts *LoginOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("authentication failed for %s (HTTP %d)", opts.Host, resp.StatusCode)


### PR DESCRIPTION
## Summary

Closes #97

`resp.Body.Close()` was called before `io.ReadAll(resp.Body)`, causing `Error: file already closed` on every interactive login.

## Fix

Replace `_ = resp.Body.Close()` with `defer resp.Body.Close()`.

## Test plan

- [x] Unit tests pass
- [ ] Manual: `copia-cli auth login` with valid token succeeds