### PR TITLE
fix: realworld test fixes (#100, #101, #102, #104)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDFLAGS := -s -w \
 	-X github.com/qubernetic/copia-cli/internal/build.Version=$(VERSION) \
 	-X github.com/qubernetic/copia-cli/internal/build.Date=$(DATE)
 
-.PHONY: build test integration acceptance docs clean
+.PHONY: build test integration acceptance docs clean snapshot install uninstall update
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o bin/$(BIN) ./cmd/copia-cli
@@ -23,4 +23,17 @@ docs:
 	go run script/gen-docs.go
 
 clean:
-	rm -rf bin/ site/
+	rm -rf bin/ dist/
+
+snapshot:
+	goreleaser release --snapshot --clean
+
+install:
+	sudo dnf install -y dist/$(BIN)_*_linux_amd64.rpm
+
+uninstall:
+	sudo dnf remove -y $(BIN)
+
+update: snapshot
+	sudo dnf remove -y $(BIN) || true
+	sudo dnf install -y dist/$(BIN)_*_linux_amd64.rpm

--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -130,7 +130,7 @@ func apiRun(opts *APIOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNoContent {
 		return nil

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -59,7 +59,7 @@ func statusRun(opts *StatusOptions) error {
 				if err != nil {
 					tokenStatus = fmt.Sprintf("Error: %v", err)
 				} else {
-					_ = resp.Body.Close()
+					defer func() { _ = resp.Body.Close() }()
 					if resp.StatusCode != http.StatusOK {
 						tokenStatus = fmt.Sprintf("Token invalid (HTTP %d)", resp.StatusCode)
 					}

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -85,7 +85,7 @@ func closeRun(opts *CloseOptions) error {
 		if err != nil {
 			return err
 		}
-		_ = resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusCreated {
 			return fmt.Errorf("failed to add comment (HTTP %d)", resp.StatusCode)
 		}
@@ -106,9 +106,9 @@ func closeRun(opts *CloseOptions) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to close issue (HTTP %d)", resp.StatusCode)
 	}
 

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -87,7 +87,7 @@ func commentRun(opts *CommentOptions) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to add comment (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -104,7 +104,7 @@ func createRun(opts *CreateOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -135,9 +135,9 @@ func updateIssue(opts *EditOptions) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to update issue (HTTP %d)", resp.StatusCode)
 	}
 
@@ -174,9 +174,9 @@ func addLabels(opts *EditOptions) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to add labels (HTTP %d)", resp.StatusCode)
 	}
 
@@ -202,7 +202,7 @@ func resolveLabelIDs(opts *EditOptions) ([]int64, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -94,7 +94,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -104,7 +104,7 @@ func viewRun(opts *ViewOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("issue #%d not found", opts.Number)

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -97,7 +97,7 @@ func createRun(opts *CreateOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to create label (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/label/list/list.go
+++ b/pkg/cmd/label/list/list.go
@@ -82,7 +82,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/notification/list/list.go
+++ b/pkg/cmd/notification/list/list.go
@@ -73,7 +73,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/notification/read/read.go
+++ b/pkg/cmd/notification/read/read.go
@@ -80,7 +80,7 @@ func readRun(opts *ReadOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusResetContent && resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("failed to mark as read (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/org/list/list.go
+++ b/pkg/cmd/org/list/list.go
@@ -64,7 +64,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/org/view/view.go
+++ b/pkg/cmd/org/view/view.go
@@ -65,7 +65,7 @@ func viewRun(opts *ViewOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("organization %s not found", opts.Name)

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -80,9 +80,9 @@ func closeRun(opts *CloseOptions) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to close PR (HTTP %d)", resp.StatusCode)
 	}
 

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -108,7 +108,7 @@ func createRun(opts *CreateOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -75,7 +75,7 @@ func diffRun(opts *DiffOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("PR #%d not found", opts.Number)

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -100,7 +100,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -115,9 +115,9 @@ func mergeRun(opts *MergeOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to merge PR (HTTP %d)", resp.StatusCode)
 	}
 

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -117,9 +117,9 @@ func reviewRun(opts *ReviewOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("failed to submit review (HTTP %d)", resp.StatusCode)
 	}
 

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -105,7 +105,7 @@ func viewRun(opts *ViewOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("PR #%d not found", opts.Number)

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -113,7 +113,7 @@ func createRun(opts *CreateOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -86,7 +86,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -152,7 +152,7 @@ func uploadFile(opts *UploadOptions, releaseID int64, filePath string) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("HTTP %d", resp.StatusCode)

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -34,11 +34,12 @@ func NewCmdClone(f *cmdutil.Factory) *cobra.Command {
 			opts.IO = f.IOStreams
 			opts.Repo = args[0]
 
-			host, _, err := f.ResolveAuth()
+			host, token, err := f.ResolveAuth()
 			if err != nil {
 				return err
 			}
 			opts.Host = host
+			opts.Token = token
 
 			if len(args) > 1 {
 				opts.Dir = args[1]
@@ -54,17 +55,39 @@ func NewCmdClone(f *cmdutil.Factory) *cobra.Command {
 func cloneRun(opts *CloneOptions) error {
 	cloneURL := buildCloneURL(opts.Host, opts.Repo)
 
-	args := []string{"clone", "--", cloneURL}
-	if opts.Dir != "" {
-		args = append(args, opts.Dir)
+	// Use token in URL for authentication, then remove it from the remote.
+	authURL := cloneURL
+	if opts.Token != "" && !strings.HasPrefix(opts.Repo, "git@") {
+		authURL = buildAuthCloneURL(opts.Host, opts.Token, opts.Repo)
+	}
+
+	args := []string{"clone", "--", authURL}
+	dir := opts.Dir
+	if dir != "" {
+		args = append(args, dir)
+	} else {
+		// Derive dir name from repo for post-clone remote fix
+		parts := strings.Split(strings.TrimSuffix(opts.Repo, ".git"), "/")
+		dir = parts[len(parts)-1]
 	}
 
 	gitCmd := exec.Command("git", args...)
 	gitCmd.Stdout = opts.IO.Out
 	gitCmd.Stderr = opts.IO.ErrOut
 	gitCmd.Stdin = os.Stdin
+	gitCmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 
-	return gitCmd.Run()
+	if err := gitCmd.Run(); err != nil {
+		return err
+	}
+
+	// Remove token from the stored remote URL
+	if opts.Token != "" && authURL != cloneURL {
+		setCmd := exec.Command("git", "-C", dir, "remote", "set-url", "origin", cloneURL)
+		_ = setCmd.Run()
+	}
+
+	return nil
 }
 
 func buildCloneURL(host, repo string) string {
@@ -72,4 +95,11 @@ func buildCloneURL(host, repo string) string {
 		return repo
 	}
 	return fmt.Sprintf("https://%s/%s.git", host, repo)
+}
+
+func buildAuthCloneURL(host, token, repo string) string {
+	if strings.HasPrefix(repo, "https://") {
+		return strings.Replace(repo, "https://", fmt.Sprintf("https://token:%s@", token), 1)
+	}
+	return fmt.Sprintf("https://token:%s@%s/%s.git", token, host, repo)
 }

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -100,7 +100,7 @@ func createRun(opts *CreateOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -68,7 +68,7 @@ func deleteRun(opts *DeleteOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("failed to delete repository (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -85,7 +85,7 @@ func forkRun(opts *ForkOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -80,7 +80,7 @@ func listRun(opts *ListOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -93,7 +93,7 @@ func viewRun(opts *ViewOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return fmt.Errorf("repository %s/%s not found", opts.Owner, opts.Repo)

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -93,7 +93,7 @@ func searchRun(opts *SearchOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -79,7 +79,7 @@ func searchRun(opts *SearchOptions) error {
 	if err != nil {
 		return fmt.Errorf("connecting to %s: %w", opts.Host, err)
 	}
-	_ = resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("API error (HTTP %d)", resp.StatusCode)


### PR DESCRIPTION
## Summary

Closes #100, #101, #102, #104

Fixes discovered during real-world testing of the installed rpm package (v0.5.0-rc.1).

### Fix: defer resp.Body.Close (#100)
- 31 files: `_ = resp.Body.Close()` → `defer func() { _ = resp.Body.Close() }()`
- Body was closed before `io.ReadAll`, causing "file already closed" on every command

### Fix: accept 201 from Gitea (#102)
- issue close/edit, pr close/merge/review: Gitea returns 201 for PATCH/POST
- Previously only 200 was accepted, causing false "failed" errors

### Fix: authenticate repo clone (#101)
- Private repos couldn't be cloned — no auth was passed to git
- Token embedded in clone URL, then stripped from remote after cloning
- `GIT_TERMINAL_PROMPT=0` prevents interactive hangs

### Chore: Makefile dev targets (#104)
- `make snapshot` — local GoReleaser build
- `make install/uninstall/update` — rpm lifecycle

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Snapshot build succeeds (`goreleaser release --snapshot --clean`)
- [x] RPM install + full realworld test of all commands
- [x] 91-point gh CLI behavior comparison (78 PASS, 8 PARTIAL, 5 FAIL — all fails are pre-existing feature gaps, not regressions)