### PR TITLE
fix: resolve GoReleaser v2 archive format deprecations (#96)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,11 +38,13 @@ universal_binaries:
     name_template: "copia-cli"
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
## Summary

Closes #96 (partially)

Fixes 2 of 3 GoReleaser deprecation warnings:
- `archives.format` → `archives.formats` (list)
- `archives.format_overrides.format` → `archives.format_overrides.formats`

### brews deprecation

The `brews` → `homebrew_formulas` migration is **not yet possible** — `homebrew_formulas` is not recognized by GoReleaser v2.15.x (used in CI). The `brews` key still works, just with a warning. Will revisit when GoReleaser adds the new key.

## Test plan

- [x] `goreleaser release --snapshot --clean` succeeds
- [x] Only 1 warning remains (brews, not actionable)