### PR TITLE
feat: add -R/--repo flag for repo-scoped commands (#105)

### DIFF
--- a/internal/copiacmd/root.go
+++ b/internal/copiacmd/root.go
@@ -38,6 +38,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	// Global flags — bound to factory fields, resolved in ResolveAuth()
 	cmd.PersistentFlags().StringVar(&f.Host, "host", "", "Target Copia host")
 	cmd.PersistentFlags().StringVar(&f.Token, "token", "", "Authentication token")
+	cmd.PersistentFlags().StringVarP(&f.Repo, "repo", "R", "", "Select repository (owner/repo)")
 
 	cmd.AddCommand(authCmd.NewCmdAuth(f))
 	cmd.AddCommand(repoCmd.NewCmdRepo(f))

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -49,10 +49,7 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -48,10 +48,7 @@ func NewCmdComment(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -55,10 +55,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -54,10 +54,7 @@ func NewCmdEdit(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -59,10 +59,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -71,10 +71,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -48,10 +48,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/label/list/list.go
+++ b/pkg/cmd/label/list/list.go
@@ -51,10 +51,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -47,10 +47,7 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -57,10 +57,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -44,10 +44,7 @@ func NewCmdDiff(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -65,10 +65,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -56,10 +56,7 @@ func NewCmdMerge(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -54,10 +54,7 @@ func NewCmdReview(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -72,10 +72,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -61,10 +61,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/release/delete/delete.go
+++ b/pkg/cmd/release/delete/delete.go
@@ -40,10 +40,7 @@ func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -52,10 +52,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -46,10 +46,7 @@ func NewCmdUpload(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -61,14 +61,12 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 					return err
 				}
 				opts.Owner, opts.Repo = owner, repo
-			} else if f.BaseRepo != nil {
-				owner, repo, err := f.BaseRepo()
+			} else {
+				owner, repo, err := f.ResolveRepo()
 				if err != nil {
 					return fmt.Errorf("could not determine repository: %w", err)
 				}
 				opts.Owner, opts.Repo = owner, repo
-			} else {
-				return fmt.Errorf("could not determine repository. Provide owner/repo as argument")
 			}
 
 			opts.HTTPClient = &http.Client{}

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -55,10 +55,7 @@ func NewCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 
-			if f.BaseRepo == nil {
-				return fmt.Errorf("could not determine repository. Run from inside a git repository")
-			}
-			owner, repo, err := f.BaseRepo()
+			owner, repo, err := f.ResolveRepo()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -14,9 +14,10 @@ type Factory struct {
 	Config   func() (*config.Config, error)
 	BaseRepo func() (string, string, error) // returns owner, repo
 
-	// Overrides (flags only — env vars resolved in ResolveAuth)
+	// Overrides (flags only ��� env vars resolved in ResolveAuth)
 	Token string
 	Host  string
+	Repo  string // -R/--repo flag override for BaseRepo
 }
 
 // ResolveAuth returns the host and token, resolving in order:
@@ -60,4 +61,17 @@ func (f *Factory) ResolveAuth() (host, token string, err error) {
 		return "", "", fmt.Errorf("no token configured for %s. Run 'copia auth login' first", host)
 	}
 	return host, token, nil
+}
+
+// ResolveRepo returns owner and repo, resolving in order:
+// 1. -R/--repo flag (highest priority)
+// 2. BaseRepo from git remote (fallback)
+func (f *Factory) ResolveRepo() (owner, repo string, err error) {
+	if f.Repo != "" {
+		return SplitOwnerRepo(f.Repo)
+	}
+	if f.BaseRepo == nil {
+		return "", "", fmt.Errorf("could not determine repository. Use -R owner/repo or run from inside a git repository")
+	}
+	return f.BaseRepo()
 }

--- a/pkg/cmdutil/factory_test.go
+++ b/pkg/cmdutil/factory_test.go
@@ -98,6 +98,51 @@ func TestFactory_ResolveAuth_NoConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "no host configured")
 }
 
+func TestFactory_ResolveRepo_FlagOverride(t *testing.T) {
+	f := &Factory{
+		Repo: "flag-org/flag-repo",
+		BaseRepo: func() (string, string, error) {
+			return "git-org", "git-repo", nil
+		},
+	}
+
+	owner, repo, err := f.ResolveRepo()
+	assert.NoError(t, err)
+	assert.Equal(t, "flag-org", owner)
+	assert.Equal(t, "flag-repo", repo)
+}
+
+func TestFactory_ResolveRepo_BaseRepoFallback(t *testing.T) {
+	f := &Factory{
+		BaseRepo: func() (string, string, error) {
+			return "git-org", "git-repo", nil
+		},
+	}
+
+	owner, repo, err := f.ResolveRepo()
+	assert.NoError(t, err)
+	assert.Equal(t, "git-org", owner)
+	assert.Equal(t, "git-repo", repo)
+}
+
+func TestFactory_ResolveRepo_NoRepoNoBaseRepo(t *testing.T) {
+	f := &Factory{}
+
+	_, _, err := f.ResolveRepo()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not determine repository")
+}
+
+func TestFactory_ResolveRepo_InvalidFormat(t *testing.T) {
+	f := &Factory{
+		Repo: "invalid-no-slash",
+	}
+
+	_, _, err := f.ResolveRepo()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expected owner/repo format")
+}
+
 func TestParseRemoteURL_HTTPS(t *testing.T) {
 	owner, repo, err := ParseRemoteURL("https://app.copia.io/my-org/my-repo.git")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

Closes #105

Adds `-R`/`--repo` global flag matching `gh` CLI behavior. Users and AI agents can now target any repo without cloning.

### Changes

1. **Factory**: Added `Repo` field and `ResolveRepo()` method (`-R flag` > `git remote`)
2. **Root command**: Registered `-R`/`--repo` persistent flag
3. **21 commands**: Replaced `BaseRepo` nil-check + call with `f.ResolveRepo()`

### Usage

```
copia-cli issue list -R owner/repo
copia-cli pr view 123 -R owner/repo
copia-cli label list -R owner/repo
```

## Test plan

- [x] Unit tests for ResolveRepo (flag override, BaseRepo fallback, no repo error, invalid format)
- [x] All existing unit tests pass
- [x] Manual test: `-R` flag works from outside a git repo
- [x] Manual test: invalid `-R` value gives clear error