### PR TITLE
test: rewrite integration tests to exercise CLI code paths (#103)

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -56,7 +56,7 @@ func NewCmdAPI(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return apiRun(opts)
+			return APIRun(opts)
 		},
 	}
 
@@ -67,7 +67,7 @@ func NewCmdAPI(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func apiRun(opts *APIOptions) error {
+func APIRun(opts *APIOptions) error {
 	if opts.Path == "" {
 		return fmt.Errorf("path required")
 	}

--- a/pkg/cmd/api/api_test.go
+++ b/pkg/cmd/api/api_test.go
@@ -30,7 +30,7 @@ func TestApiRun_GET(t *testing.T) {
 		Path:       "/user",
 	}
 
-	err := apiRun(opts)
+	err := APIRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "john")
 }
@@ -56,7 +56,7 @@ func TestApiRun_POST_WithFields(t *testing.T) {
 		Fields:     []string{"title=test issue", "body=description"},
 	}
 
-	err := apiRun(opts)
+	err := APIRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "test issue")
 }
@@ -81,7 +81,7 @@ func TestApiRun_DELETE(t *testing.T) {
 		Path:       "/repos/my-org/my-repo",
 	}
 
-	err := apiRun(opts)
+	err := APIRun(opts)
 	require.NoError(t, err)
 }
 
@@ -104,7 +104,7 @@ func TestApiRun_DefaultMethodGET(t *testing.T) {
 		Path:       "/version",
 	}
 
-	err := apiRun(opts)
+	err := APIRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "1.21.0")
 }
@@ -114,7 +114,7 @@ func TestApiRun_MissingPath(t *testing.T) {
 
 	opts := &APIOptions{IO: ios, Path: ""}
 
-	err := apiRun(opts)
+	err := APIRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "path required")
 }

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -65,7 +65,7 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			opts.HTTPClient = &http.Client{}
-			return loginRun(opts)
+			return LoginRun(opts)
 		},
 	}
 
@@ -80,7 +80,7 @@ type userResponse struct {
 	ID    int64  `json:"id"`
 }
 
-func loginRun(opts *LoginOptions) error {
+func LoginRun(opts *LoginOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/user", opts.Host)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/auth/login/login_test.go
+++ b/pkg/cmd/auth/login/login_test.go
@@ -31,7 +31,7 @@ func TestLoginRun_NonInteractive_Success(t *testing.T) {
 		HTTPClient: &http.Client{Transport: reg},
 	}
 
-	err := loginRun(opts)
+	err := LoginRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Logged in as john")
 
@@ -60,7 +60,7 @@ func TestLoginRun_InvalidToken(t *testing.T) {
 		HTTPClient: &http.Client{Transport: reg},
 	}
 
-	err := loginRun(opts)
+	err := LoginRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication failed")
 }

--- a/pkg/cmd/auth/status/status.go
+++ b/pkg/cmd/auth/status/status.go
@@ -29,14 +29,14 @@ func NewCmdStatus(f *cmdutil.Factory) *cobra.Command {
 			opts.IO = f.IOStreams
 			opts.ConfigPath = config.DefaultPath()
 			opts.HTTPClient = &http.Client{}
-			return statusRun(opts)
+			return StatusRun(opts)
 		},
 	}
 
 	return cmd
 }
 
-func statusRun(opts *StatusOptions) error {
+func StatusRun(opts *StatusOptions) error {
 	cfg, err := config.Load(opts.ConfigPath)
 	if err != nil {
 		return err

--- a/pkg/cmd/auth/status/status_test.go
+++ b/pkg/cmd/auth/status/status_test.go
@@ -36,7 +36,7 @@ func TestStatusRun_LoggedIn(t *testing.T) {
 		HTTPClient: &http.Client{Transport: reg},
 	}
 
-	err := statusRun(opts)
+	err := StatusRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "app.copia.io")
 	assert.Contains(t, stdout.String(), "john")
@@ -55,7 +55,7 @@ func TestStatusRun_NoHosts(t *testing.T) {
 		ConfigPath: configPath,
 	}
 
-	err := statusRun(opts)
+	err := StatusRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not logged in")
 }
@@ -85,7 +85,7 @@ func TestStatusRun_InvalidToken(t *testing.T) {
 		HTTPClient: &http.Client{Transport: reg},
 	}
 
-	err := statusRun(opts)
+	err := StatusRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Token invalid")
 }

--- a/pkg/cmd/issue/close/close.go
+++ b/pkg/cmd/issue/close/close.go
@@ -56,7 +56,7 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return closeRun(opts)
+			return CloseRun(opts)
 		},
 	}
 
@@ -65,7 +65,7 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func closeRun(opts *CloseOptions) error {
+func CloseRun(opts *CloseOptions) error {
 	if opts.Comment != "" {
 		commentPayload, _ := json.Marshal(map[string]string{"body": opts.Comment})
 		commentURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d/comments",

--- a/pkg/cmd/issue/close/close_test.go
+++ b/pkg/cmd/issue/close/close_test.go
@@ -31,7 +31,7 @@ func TestCloseRun_Success(t *testing.T) {
 		Number:     12,
 	}
 
-	err := closeRun(opts)
+	err := CloseRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Closed issue #12")
 }
@@ -62,7 +62,7 @@ func TestCloseRun_WithComment(t *testing.T) {
 		Comment:    "Fixed in PR #7",
 	}
 
-	err := closeRun(opts)
+	err := CloseRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Closed issue #12")
 }

--- a/pkg/cmd/issue/comment/comment.go
+++ b/pkg/cmd/issue/comment/comment.go
@@ -55,7 +55,7 @@ func NewCmdComment(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return commentRun(opts)
+			return CommentRun(opts)
 		},
 	}
 
@@ -64,7 +64,7 @@ func NewCmdComment(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func commentRun(opts *CommentOptions) error {
+func CommentRun(opts *CommentOptions) error {
 	if opts.Body == "" {
 		return fmt.Errorf("body required")
 	}

--- a/pkg/cmd/issue/comment/comment_test.go
+++ b/pkg/cmd/issue/comment/comment_test.go
@@ -32,7 +32,7 @@ func TestCommentRun_Success(t *testing.T) {
 		Body:       "Investigating this now.",
 	}
 
-	err := commentRun(opts)
+	err := CommentRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Comment added to issue #12")
 }
@@ -42,7 +42,7 @@ func TestCommentRun_MissingBody(t *testing.T) {
 
 	opts := &CommentOptions{IO: ios, Body: ""}
 
-	err := commentRun(opts)
+	err := CommentRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "body required")
 }

--- a/pkg/cmd/issue/create/create.go
+++ b/pkg/cmd/issue/create/create.go
@@ -62,7 +62,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return createRun(opts)
+			return CreateRun(opts)
 		},
 	}
 
@@ -73,7 +73,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func createRun(opts *CreateOptions) error {
+func CreateRun(opts *CreateOptions) error {
 	if opts.Title == "" {
 		return fmt.Errorf("title required")
 	}

--- a/pkg/cmd/issue/create/create_test.go
+++ b/pkg/cmd/issue/create/create_test.go
@@ -32,7 +32,7 @@ func TestCreateRun_Success(t *testing.T) {
 		Body:       "The sensor I/O mapping is incorrect.",
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "#13")
 }
@@ -42,7 +42,7 @@ func TestCreateRun_MissingTitle(t *testing.T) {
 
 	opts := &CreateOptions{IO: ios, Title: ""}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "title required")
 }

--- a/pkg/cmd/issue/edit/edit.go
+++ b/pkg/cmd/issue/edit/edit.go
@@ -61,7 +61,7 @@ func NewCmdEdit(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return editRun(opts)
+			return EditRun(opts)
 		},
 	}
 
@@ -74,7 +74,7 @@ func NewCmdEdit(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func editRun(opts *EditOptions) error {
+func EditRun(opts *EditOptions) error {
 	hasIssueUpdate := opts.Title != "" || opts.Body != "" || len(opts.Assignees) > 0 || opts.Milestone > 0
 	hasLabelAdd := len(opts.AddLabels) > 0
 

--- a/pkg/cmd/issue/edit/edit_test.go
+++ b/pkg/cmd/issue/edit/edit_test.go
@@ -32,7 +32,7 @@ func TestEditRun_SetTitle(t *testing.T) {
 		Title:      "Updated title",
 	}
 
-	err := editRun(opts)
+	err := EditRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Updated issue #12")
 }
@@ -63,7 +63,7 @@ func TestEditRun_AddLabels(t *testing.T) {
 		AddLabels:  []string{"bug"},
 	}
 
-	err := editRun(opts)
+	err := EditRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Updated issue #12")
 }
@@ -90,7 +90,7 @@ func TestEditRun_SetAssignees(t *testing.T) {
 		Assignees:  []string{"john", "jane"},
 	}
 
-	err := editRun(opts)
+	err := EditRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Updated issue #12")
 }
@@ -117,7 +117,7 @@ func TestEditRun_SetMilestone(t *testing.T) {
 		Milestone:  1,
 	}
 
-	err := editRun(opts)
+	err := EditRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Updated issue #12")
 }
@@ -130,7 +130,7 @@ func TestEditRun_NothingToEdit(t *testing.T) {
 		Number: 12,
 	}
 
-	err := editRun(opts)
+	err := EditRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "nothing to edit")
 }

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -66,7 +66,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -77,7 +77,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=%s&limit=%d&type=issues",
 		opts.Host, opts.Owner, opts.Repo, opts.State, opts.Limit)
 

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -36,7 +36,7 @@ func TestListRun_Success(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Fix PLC connection timeout")
 	assert.Contains(t, stdout.String(), "12")
@@ -67,7 +67,7 @@ func TestListRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"number", "title"}},
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"number"`)
 }

--- a/pkg/cmd/issue/view/view.go
+++ b/pkg/cmd/issue/view/view.go
@@ -78,7 +78,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return viewRun(opts)
+			return ViewRun(opts)
 		},
 	}
 
@@ -87,7 +87,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func viewRun(opts *ViewOptions) error {
+func ViewRun(opts *ViewOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d",
 		opts.Host, opts.Owner, opts.Repo, opts.Number)
 

--- a/pkg/cmd/issue/view/view_test.go
+++ b/pkg/cmd/issue/view/view_test.go
@@ -38,7 +38,7 @@ func TestViewRun_Success(t *testing.T) {
 		Number:     12,
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Fix PLC connection timeout")
 	assert.Contains(t, stdout.String(), "john")
@@ -69,7 +69,7 @@ func TestViewRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"number", "title"}},
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"number"`)
 }
@@ -95,7 +95,7 @@ func TestViewRun_NotFound(t *testing.T) {
 		Number:     999,
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }

--- a/pkg/cmd/label/create/create.go
+++ b/pkg/cmd/label/create/create.go
@@ -55,7 +55,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return createRun(opts)
+			return CreateRun(opts)
 		},
 	}
 
@@ -66,7 +66,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func createRun(opts *CreateOptions) error {
+func CreateRun(opts *CreateOptions) error {
 	if opts.Name == "" {
 		return fmt.Errorf("name required")
 	}

--- a/pkg/cmd/label/create/create_test.go
+++ b/pkg/cmd/label/create/create_test.go
@@ -33,7 +33,7 @@ func TestCreateRun_Success(t *testing.T) {
 		Description: "Critical issue",
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "critical")
 }
@@ -46,7 +46,7 @@ func TestCreateRun_MissingName(t *testing.T) {
 		Name: "",
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "name required")
 }

--- a/pkg/cmd/label/list/list.go
+++ b/pkg/cmd/label/list/list.go
@@ -58,7 +58,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -67,7 +67,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/labels", opts.Host, opts.Owner, opts.Repo)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/label/list/list_test.go
+++ b/pkg/cmd/label/list/list_test.go
@@ -34,7 +34,7 @@ func TestListRun_Success(t *testing.T) {
 		Repo:       "my-repo",
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "bug")
 	assert.Contains(t, stdout.String(), "feature")
@@ -63,7 +63,7 @@ func TestListRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"name", "color"}},
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"name"`)
 	assert.Contains(t, stdout.String(), "bug")

--- a/pkg/cmd/notification/list/list.go
+++ b/pkg/cmd/notification/list/list.go
@@ -53,7 +53,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -61,7 +61,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/notifications", opts.Host)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/notification/list/list_test.go
+++ b/pkg/cmd/notification/list/list_test.go
@@ -31,7 +31,7 @@ func TestListRun_Success(t *testing.T) {
 		Token:      "test-token",
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Fix PLC timeout")
 	assert.Contains(t, stdout.String(), "Add sensor")

--- a/pkg/cmd/notification/read/read.go
+++ b/pkg/cmd/notification/read/read.go
@@ -50,7 +50,7 @@ func NewCmdRead(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			opts.HTTPClient = &http.Client{}
-			return readRun(opts)
+			return ReadRun(opts)
 		},
 	}
 
@@ -59,7 +59,7 @@ func NewCmdRead(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func readRun(opts *ReadOptions) error {
+func ReadRun(opts *ReadOptions) error {
 	var method, url string
 
 	if opts.All {

--- a/pkg/cmd/notification/read/read_test.go
+++ b/pkg/cmd/notification/read/read_test.go
@@ -29,7 +29,7 @@ func TestReadRun_MarkAll(t *testing.T) {
 		All:        true,
 	}
 
-	err := readRun(opts)
+	err := ReadRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "All notifications marked as read")
 }
@@ -53,7 +53,7 @@ func TestReadRun_MarkSingle(t *testing.T) {
 		ThreadID:   42,
 	}
 
-	err := readRun(opts)
+	err := ReadRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Notification #42 marked as read")
 }

--- a/pkg/cmd/org/list/list.go
+++ b/pkg/cmd/org/list/list.go
@@ -44,7 +44,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -52,7 +52,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/user/orgs", opts.Host)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/org/list/list_test.go
+++ b/pkg/cmd/org/list/list_test.go
@@ -32,7 +32,7 @@ func TestListRun_Success(t *testing.T) {
 		Token:      "test-token",
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "my-org")
 	assert.Contains(t, stdout.String(), "other-org")
@@ -57,7 +57,7 @@ func TestListRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"username"}},
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"username"`)
 }

--- a/pkg/cmd/org/view/view.go
+++ b/pkg/cmd/org/view/view.go
@@ -45,7 +45,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return viewRun(opts)
+			return ViewRun(opts)
 		},
 	}
 
@@ -53,7 +53,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func viewRun(opts *ViewOptions) error {
+func ViewRun(opts *ViewOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/orgs/%s", opts.Host, opts.Name)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/org/view/view_test.go
+++ b/pkg/cmd/org/view/view_test.go
@@ -29,7 +29,7 @@ func TestViewRun_Success(t *testing.T) {
 		Name:       "my-org",
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "my-org")
 	assert.Contains(t, stdout.String(), "Industrial automation")

--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -54,14 +54,14 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return closeRun(opts)
+			return CloseRun(opts)
 		},
 	}
 
 	return cmd
 }
 
-func closeRun(opts *CloseOptions) error {
+func CloseRun(opts *CloseOptions) error {
 	payload, _ := json.Marshal(map[string]string{"state": "closed"})
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d",
 		opts.Host, opts.Owner, opts.Repo, opts.Number)

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -31,7 +31,7 @@ func TestCloseRun_Success(t *testing.T) {
 		Number:     7,
 	}
 
-	err := closeRun(opts)
+	err := CloseRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Closed PR #7")
 }

--- a/pkg/cmd/pr/create/create.go
+++ b/pkg/cmd/pr/create/create.go
@@ -64,7 +64,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return createRun(opts)
+			return CreateRun(opts)
 		},
 	}
 
@@ -76,7 +76,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func createRun(opts *CreateOptions) error {
+func CreateRun(opts *CreateOptions) error {
 	if opts.Title == "" {
 		return fmt.Errorf("title required")
 	}

--- a/pkg/cmd/pr/create/create_test.go
+++ b/pkg/cmd/pr/create/create_test.go
@@ -37,7 +37,7 @@ func TestCreateRun_Success(t *testing.T) {
 		Head:       "feature/cylinder",
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "#8")
 }
@@ -46,7 +46,7 @@ func TestCreateRun_MissingTitle(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	opts := &CreateOptions{IO: ios, Title: ""}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "title required")
 }

--- a/pkg/cmd/pr/diff/diff.go
+++ b/pkg/cmd/pr/diff/diff.go
@@ -51,14 +51,14 @@ func NewCmdDiff(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return diffRun(opts)
+			return DiffRun(opts)
 		},
 	}
 
 	return cmd
 }
 
-func diffRun(opts *DiffOptions) error {
+func DiffRun(opts *DiffOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d.diff",
 		opts.Host, opts.Owner, opts.Repo, opts.Number)
 

--- a/pkg/cmd/pr/diff/diff_test.go
+++ b/pkg/cmd/pr/diff/diff_test.go
@@ -41,7 +41,7 @@ index abc1234..def5678 100644
 		Number:     7,
 	}
 
-	err := diffRun(opts)
+	err := DiffRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "diff --git")
 	assert.Contains(t, stdout.String(), "+import \"fmt\"")

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -72,7 +72,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -83,7 +83,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls?state=%s&limit=%d",
 		opts.Host, opts.Owner, opts.Repo, opts.State, opts.Limit)
 

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -36,7 +36,7 @@ func TestListRun_Success(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "add cylinder wrapper")
 	assert.Contains(t, stdout.String(), "sensor timeout")
@@ -67,7 +67,7 @@ func TestListRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"number", "title"}},
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"number"`)
 }

--- a/pkg/cmd/pr/merge/merge.go
+++ b/pkg/cmd/pr/merge/merge.go
@@ -75,7 +75,7 @@ func NewCmdMerge(f *cmdutil.Factory) *cobra.Command {
 				opts.Method = "merge"
 			}
 
-			return mergeRun(opts)
+			return MergeRun(opts)
 		},
 	}
 
@@ -87,7 +87,7 @@ func NewCmdMerge(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func mergeRun(opts *MergeOptions) error {
+func MergeRun(opts *MergeOptions) error {
 	payload := mergeRequest{
 		Do:                    opts.Method,
 		DeleteBranchAfterMerge: opts.DeleteBranch,

--- a/pkg/cmd/pr/merge/merge_test.go
+++ b/pkg/cmd/pr/merge/merge_test.go
@@ -32,7 +32,7 @@ func TestMergeRun_Success(t *testing.T) {
 		Method:     "merge",
 	}
 
-	err := mergeRun(opts)
+	err := MergeRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Merged PR #7")
 }
@@ -59,7 +59,7 @@ func TestMergeRun_Squash(t *testing.T) {
 		Method:     "squash",
 	}
 
-	err := mergeRun(opts)
+	err := MergeRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Merged PR #7")
 }
@@ -87,7 +87,7 @@ func TestMergeRun_WithDeleteBranch(t *testing.T) {
 		DeleteBranch: true,
 	}
 
-	err := mergeRun(opts)
+	err := MergeRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Merged PR #7")
 }

--- a/pkg/cmd/pr/review/review.go
+++ b/pkg/cmd/pr/review/review.go
@@ -77,7 +77,7 @@ func NewCmdReview(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			opts.HTTPClient = &http.Client{}
-			return reviewRun(opts)
+			return ReviewRun(opts)
 		},
 	}
 
@@ -89,7 +89,7 @@ func NewCmdReview(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func reviewRun(opts *ReviewOptions) error {
+func ReviewRun(opts *ReviewOptions) error {
 	payload := reviewRequest{
 		Event: opts.Event,
 		Body:  opts.Body,

--- a/pkg/cmd/pr/review/review_test.go
+++ b/pkg/cmd/pr/review/review_test.go
@@ -32,7 +32,7 @@ func TestReviewRun_Approve(t *testing.T) {
 		Event:      "APPROVED",
 	}
 
-	err := reviewRun(opts)
+	err := ReviewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Approved PR #7")
 }
@@ -60,7 +60,7 @@ func TestReviewRun_RequestChanges(t *testing.T) {
 		Body:       "Please fix the tests.",
 	}
 
-	err := reviewRun(opts)
+	err := ReviewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Requested changes on PR #7")
 }
@@ -88,7 +88,7 @@ func TestReviewRun_Comment(t *testing.T) {
 		Body:       "Looks good overall.",
 	}
 
-	err := reviewRun(opts)
+	err := ReviewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Commented on PR #7")
 }

--- a/pkg/cmd/pr/view/view.go
+++ b/pkg/cmd/pr/view/view.go
@@ -79,7 +79,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return viewRun(opts)
+			return ViewRun(opts)
 		},
 	}
 
@@ -88,7 +88,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func viewRun(opts *ViewOptions) error {
+func ViewRun(opts *ViewOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d",
 		opts.Host, opts.Owner, opts.Repo, opts.Number)
 

--- a/pkg/cmd/pr/view/view_test.go
+++ b/pkg/cmd/pr/view/view_test.go
@@ -38,7 +38,7 @@ func TestViewRun_Success(t *testing.T) {
 		Number:     7,
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "feat: add cylinder wrapper")
 	assert.Contains(t, stdout.String(), "john")
@@ -71,7 +71,7 @@ func TestViewRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"number", "title"}},
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"number"`)
 }

--- a/pkg/cmd/release/create/create.go
+++ b/pkg/cmd/release/create/create.go
@@ -68,7 +68,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return createRun(opts)
+			return CreateRun(opts)
 		},
 	}
 
@@ -80,7 +80,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func createRun(opts *CreateOptions) error {
+func CreateRun(opts *CreateOptions) error {
 	if opts.Tag == "" {
 		return fmt.Errorf("tag required")
 	}

--- a/pkg/cmd/release/create/create_test.go
+++ b/pkg/cmd/release/create/create_test.go
@@ -33,7 +33,7 @@ func TestCreateRun_Success(t *testing.T) {
 		Notes:      "First stable release.",
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "v1.0.0")
 }
@@ -42,7 +42,7 @@ func TestCreateRun_MissingTag(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	opts := &CreateOptions{IO: ios, Tag: ""}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tag required")
 }
@@ -70,7 +70,7 @@ func TestCreateRun_Draft(t *testing.T) {
 		Draft:      true,
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "v2.0.0-rc.1")
 }

--- a/pkg/cmd/release/delete/delete.go
+++ b/pkg/cmd/release/delete/delete.go
@@ -47,14 +47,14 @@ func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return deleteRun(opts)
+			return DeleteRun(opts)
 		},
 	}
 
 	return cmd
 }
 
-func deleteRun(opts *DeleteOptions) error {
+func DeleteRun(opts *DeleteOptions) error {
 	// First, look up release ID by tag
 	lookupURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/releases/tags/%s",
 		opts.Host, opts.Owner, opts.Repo, opts.Tag)

--- a/pkg/cmd/release/delete/delete_test.go
+++ b/pkg/cmd/release/delete/delete_test.go
@@ -35,7 +35,7 @@ func TestDeleteRun_Success(t *testing.T) {
 		Tag:        "v1.0.0",
 	}
 
-	err := deleteRun(opts)
+	err := DeleteRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Deleted release v1.0.0")
 }
@@ -61,7 +61,7 @@ func TestDeleteRun_NotFound(t *testing.T) {
 		Tag:        "v9.9.9",
 	}
 
-	err := deleteRun(opts)
+	err := DeleteRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -59,7 +59,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -69,7 +69,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/releases?limit=%d",
 		opts.Host, opts.Owner, opts.Repo, opts.Limit)
 

--- a/pkg/cmd/release/list/list_test.go
+++ b/pkg/cmd/release/list/list_test.go
@@ -35,7 +35,7 @@ func TestListRun_Success(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "v1.0.0")
 	assert.Contains(t, stdout.String(), "v0.9.0")
@@ -65,7 +65,7 @@ func TestListRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"tagName", "name"}},
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"tag_name"`)
 }

--- a/pkg/cmd/release/upload/upload.go
+++ b/pkg/cmd/release/upload/upload.go
@@ -53,14 +53,14 @@ func NewCmdUpload(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return uploadRun(opts)
+			return UploadRun(opts)
 		},
 	}
 
 	return cmd
 }
 
-func uploadRun(opts *UploadOptions) error {
+func UploadRun(opts *UploadOptions) error {
 	// Validate files exist first
 	for _, f := range opts.Files {
 		if _, err := os.Stat(f); err != nil {

--- a/pkg/cmd/release/upload/upload_test.go
+++ b/pkg/cmd/release/upload/upload_test.go
@@ -43,7 +43,7 @@ func TestUploadRun_Success(t *testing.T) {
 		Files:      []string{filePath},
 	}
 
-	err := uploadRun(opts)
+	err := UploadRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "binary.tar.gz")
 }
@@ -57,7 +57,7 @@ func TestUploadRun_FileNotFound(t *testing.T) {
 		Files: []string{"/nonexistent/file.tar.gz"},
 	}
 
-	err := uploadRun(opts)
+	err := UploadRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no such file")
 }

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -45,14 +45,14 @@ func NewCmdClone(f *cmdutil.Factory) *cobra.Command {
 				opts.Dir = args[1]
 			}
 
-			return cloneRun(opts)
+			return CloneRun(opts)
 		},
 	}
 
 	return cmd
 }
 
-func cloneRun(opts *CloneOptions) error {
+func CloneRun(opts *CloneOptions) error {
 	cloneURL := buildCloneURL(opts.Host, opts.Repo)
 
 	// Use token in URL for authentication, then remove it from the remote.

--- a/pkg/cmd/repo/create/create.go
+++ b/pkg/cmd/repo/create/create.go
@@ -56,7 +56,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return createRun(opts)
+			return CreateRun(opts)
 		},
 	}
 
@@ -67,7 +67,7 @@ func NewCmdCreate(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func createRun(opts *CreateOptions) error {
+func CreateRun(opts *CreateOptions) error {
 	if opts.Name == "" {
 		return fmt.Errorf("name required")
 	}

--- a/pkg/cmd/repo/create/create_test.go
+++ b/pkg/cmd/repo/create/create_test.go
@@ -30,7 +30,7 @@ func TestCreateRun_UserRepo(t *testing.T) {
 		Private:    true,
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "john/new-repo")
 }
@@ -55,7 +55,7 @@ func TestCreateRun_OrgRepo(t *testing.T) {
 		Org:        "my-org",
 	}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "my-org/new-repo")
 }
@@ -64,7 +64,7 @@ func TestCreateRun_MissingName(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	opts := &CreateOptions{IO: ios, Name: ""}
 
-	err := createRun(opts)
+	err := CreateRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "name required")
 }

--- a/pkg/cmd/repo/delete/delete.go
+++ b/pkg/cmd/repo/delete/delete.go
@@ -43,7 +43,7 @@ func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
 			}
 			opts.Owner, opts.Repo = owner, repo
 			opts.HTTPClient = &http.Client{}
-			return deleteRun(opts)
+			return DeleteRun(opts)
 		},
 	}
 
@@ -52,7 +52,7 @@ func NewCmdDelete(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func deleteRun(opts *DeleteOptions) error {
+func DeleteRun(opts *DeleteOptions) error {
 	if !opts.Confirmed {
 		return fmt.Errorf("deleting %s/%s is irreversible; use --yes to confirm", opts.Owner, opts.Repo)
 	}

--- a/pkg/cmd/repo/delete/delete_test.go
+++ b/pkg/cmd/repo/delete/delete_test.go
@@ -31,7 +31,7 @@ func TestDeleteRun_Success(t *testing.T) {
 		Confirmed:  true,
 	}
 
-	err := deleteRun(opts)
+	err := DeleteRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Deleted repository my-org/my-repo")
 }
@@ -46,7 +46,7 @@ func TestDeleteRun_NotConfirmed(t *testing.T) {
 		Confirmed: false,
 	}
 
-	err := deleteRun(opts)
+	err := DeleteRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "use --yes to confirm")
 }
@@ -72,7 +72,7 @@ func TestDeleteRun_NotFound(t *testing.T) {
 		Confirmed:  true,
 	}
 
-	err := deleteRun(opts)
+	err := DeleteRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete")
 }

--- a/pkg/cmd/repo/fork/fork.go
+++ b/pkg/cmd/repo/fork/fork.go
@@ -57,7 +57,7 @@ func NewCmdFork(f *cmdutil.Factory) *cobra.Command {
 			}
 			opts.Owner, opts.Repo = owner, repo
 			opts.HTTPClient = &http.Client{}
-			return forkRun(opts)
+			return ForkRun(opts)
 		},
 	}
 
@@ -66,7 +66,7 @@ func NewCmdFork(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func forkRun(opts *ForkOptions) error {
+func ForkRun(opts *ForkOptions) error {
 	payload := forkRequest{Organization: opts.Org}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/pkg/cmd/repo/fork/fork_test.go
+++ b/pkg/cmd/repo/fork/fork_test.go
@@ -30,7 +30,7 @@ func TestForkRun_Success(t *testing.T) {
 		Repo:       "project",
 	}
 
-	err := forkRun(opts)
+	err := ForkRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "john/project")
 }
@@ -56,7 +56,7 @@ func TestForkRun_ToOrg(t *testing.T) {
 		Org:        "my-org",
 	}
 
-	err := forkRun(opts)
+	err := ForkRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "my-org/project")
 }

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -52,7 +52,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return listRun(opts)
+			return ListRun(opts)
 		},
 	}
 
@@ -63,7 +63,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func listRun(opts *ListOptions) error {
+func ListRun(opts *ListOptions) error {
 	endpoint := "/api/v1/user/repos"
 	if opts.Org != "" {
 		endpoint = fmt.Sprintf("/api/v1/orgs/%s/repos", opts.Org)

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -33,7 +33,7 @@ func TestListRun_UserRepos(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "john/plc-project")
 	assert.Contains(t, stdout.String(), "john/hmi-config")
@@ -61,7 +61,7 @@ func TestListRun_OrgRepos(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "my-org/main-plc")
 }
@@ -88,7 +88,7 @@ func TestListRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"fullName", "description"}},
 	}
 
-	err := listRun(opts)
+	err := ListRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "john/plc-project")
 	assert.Contains(t, stdout.String(), "PLC code")

--- a/pkg/cmd/repo/view/view.go
+++ b/pkg/cmd/repo/view/view.go
@@ -70,7 +70,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			opts.HTTPClient = &http.Client{}
-			return viewRun(opts)
+			return ViewRun(opts)
 		},
 	}
 
@@ -79,7 +79,7 @@ func NewCmdView(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func viewRun(opts *ViewOptions) error {
+func ViewRun(opts *ViewOptions) error {
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s", opts.Host, opts.Owner, opts.Repo)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/pkg/cmd/repo/view/view_test.go
+++ b/pkg/cmd/repo/view/view_test.go
@@ -40,7 +40,7 @@ func TestViewRun_Success(t *testing.T) {
 		Repo:       "my-repo",
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "my-org/my-repo")
 	assert.Contains(t, stdout.String(), "Main PLC project")
@@ -70,7 +70,7 @@ func TestViewRun_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"fullName", "description"}},
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"full_name"`)
 }
@@ -95,7 +95,7 @@ func TestViewRun_NotFound(t *testing.T) {
 		Repo:       "missing",
 	}
 
-	err := viewRun(opts)
+	err := ViewRun(opts)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -62,7 +62,7 @@ func NewCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 			opts.Owner = owner
 			opts.Repo = repo
 			opts.HTTPClient = &http.Client{}
-			return searchRun(opts)
+			return SearchRun(opts)
 		},
 	}
 
@@ -73,7 +73,7 @@ func NewCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func searchRun(opts *SearchOptions) error {
+func SearchRun(opts *SearchOptions) error {
 	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?q=%s&limit=%d&type=issues",
 		opts.Host, opts.Owner, opts.Repo, url.QueryEscape(opts.Query), opts.Limit)
 	if opts.State != "" {

--- a/pkg/cmd/search/issues/issues_test.go
+++ b/pkg/cmd/search/issues/issues_test.go
@@ -36,7 +36,7 @@ func TestSearchIssues_Success(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := searchRun(opts)
+	err := SearchRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Fix PLC timeout")
 }

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -55,7 +55,7 @@ func NewCmdSearchRepos(f *cmdutil.Factory) *cobra.Command {
 			opts.Host = host
 			opts.Token = token
 			opts.HTTPClient = &http.Client{}
-			return searchRun(opts)
+			return SearchRun(opts)
 		},
 	}
 
@@ -65,7 +65,7 @@ func NewCmdSearchRepos(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-func searchRun(opts *SearchOptions) error {
+func SearchRun(opts *SearchOptions) error {
 	u := fmt.Sprintf("https://%s/api/v1/repos/search?q=%s&limit=%d",
 		opts.Host, url.QueryEscape(opts.Query), opts.Limit)
 

--- a/pkg/cmd/search/repos/repos_test.go
+++ b/pkg/cmd/search/repos/repos_test.go
@@ -34,7 +34,7 @@ func TestSearchRepos_Success(t *testing.T) {
 		Limit:      30,
 	}
 
-	err := searchRun(opts)
+	err := SearchRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "plc-project")
 }
@@ -62,7 +62,7 @@ func TestSearchRepos_JSON(t *testing.T) {
 		JSON:       cmdutil.JSONFlags{Fields: []string{"fullName"}},
 	}
 
-	err := searchRun(opts)
+	err := SearchRun(opts)
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"full_name"`)
 }

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -3,56 +3,71 @@
 package integration
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/qubernetic/copia-cli/pkg/cmd/auth/login"
+	"github.com/qubernetic/copia-cli/pkg/cmd/auth/status"
 )
 
-func TestAuth_ValidateToken(t *testing.T) {
+func TestAuth_LoginRun_ValidToken(t *testing.T) {
 	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
 
-	url := fmt.Sprintf("https://%s/api/v1/user", env.Host)
-	req, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "token "+env.Token)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var user struct {
-		Login string `json:"login"`
-		ID    int64  `json:"id"`
+	opts := &login.LoginOptions{
+		IO:         ios,
+		Host:       env.Host,
+		Token:      env.Token,
+		ConfigPath: filepath.Join(t.TempDir(), "config.yml"),
+		HTTPClient: &http.Client{},
 	}
-	require.NoError(t, json.Unmarshal(body, &user))
-	assert.NotEmpty(t, user.Login)
-	assert.Greater(t, user.ID, int64(0))
 
-	t.Logf("Authenticated as: %s (ID: %d)", user.Login, user.ID)
+	err := login.LoginRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Logged in as")
+	t.Logf("Output: %s", stdout.String())
 }
 
-func TestAuth_InvalidToken(t *testing.T) {
+func TestAuth_LoginRun_InvalidToken(t *testing.T) {
 	env := loadTestEnv(t)
+	ios, _, _ := testIO()
 
-	url := fmt.Sprintf("https://%s/api/v1/user", env.Host)
-	req, err := http.NewRequest("GET", url, nil)
+	opts := &login.LoginOptions{
+		IO:         ios,
+		Host:       env.Host,
+		Token:      "invalid-token-does-not-exist",
+		ConfigPath: filepath.Join(t.TempDir(), "config.yml"),
+		HTTPClient: &http.Client{},
+	}
+
+	err := login.LoginRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+func TestAuth_StatusRun(t *testing.T) {
+	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
+
+	// StatusRun reads from config file, so write one
+	configPath := filepath.Join(t.TempDir(), "config.yml")
+	configContent := []byte("hosts:\n  " + env.Host + ":\n    token: " + env.Token + "\n    user: testuser\n")
+	require.NoError(t, os.WriteFile(configPath, configContent, 0600))
+
+	opts := &status.StatusOptions{
+		IO:         ios,
+		ConfigPath: configPath,
+		HTTPClient: &http.Client{},
+	}
+
+	err := status.StatusRun(opts)
 	require.NoError(t, err)
-	req.Header.Set("Authorization", "token invalid-token-that-does-not-exist")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	// Copia/Gitea returns 403 for invalid tokens (not 401)
-	assert.Contains(t, []int{http.StatusUnauthorized, http.StatusForbidden}, resp.StatusCode)
+	assert.Contains(t, stdout.String(), env.Host)
+	assert.Contains(t, stdout.String(), "Token valid")
+	t.Logf("Output: %s", stdout.String())
 }

--- a/test/integration/helpers_test.go
+++ b/test/integration/helpers_test.go
@@ -3,8 +3,12 @@
 package integration
 
 import (
+	"bytes"
+	"net/http"
 	"os"
 	"testing"
+
+	"github.com/qubernetic/copia-cli/pkg/iostreams"
 )
 
 type testEnv struct {
@@ -32,4 +36,15 @@ func loadTestEnv(t *testing.T) testEnv {
 		Owner: owner,
 		Repo:  repo,
 	}
+}
+
+// testIO returns IOStreams and stdout buffer for asserting CLI output.
+func testIO() (*iostreams.IOStreams, *bytes.Buffer, *bytes.Buffer) {
+	ios, _, stdout, stderr := iostreams.Test()
+	return ios, stdout, stderr
+}
+
+// testHTTPClient returns a real HTTP client for integration tests.
+func testHTTPClient() *http.Client {
+	return &http.Client{}
 }

--- a/test/integration/issue_test.go
+++ b/test/integration/issue_test.go
@@ -3,136 +3,137 @@
 package integration
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	issueclose "github.com/qubernetic/copia-cli/pkg/cmd/issue/close"
+	issuecomment "github.com/qubernetic/copia-cli/pkg/cmd/issue/comment"
+	issuecreate "github.com/qubernetic/copia-cli/pkg/cmd/issue/create"
+	issueedit "github.com/qubernetic/copia-cli/pkg/cmd/issue/edit"
+	issuelist "github.com/qubernetic/copia-cli/pkg/cmd/issue/list"
+	issueview "github.com/qubernetic/copia-cli/pkg/cmd/issue/view"
 )
 
 func TestIssue_FullLifecycle(t *testing.T) {
 	env := loadTestEnv(t)
-	baseURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues", env.Host, env.Owner, env.Repo)
 
-	// Create issue
-	createPayload, _ := json.Marshal(map[string]string{
-		"title": "[integration-test] lifecycle test",
-		"body":  "Created by integration test. Will be closed automatically.",
-	})
-
-	createReq, err := http.NewRequest("POST", baseURL, bytes.NewReader(createPayload))
-	require.NoError(t, err)
-	createReq.Header.Set("Authorization", "token "+env.Token)
-	createReq.Header.Set("Content-Type", "application/json")
-
-	createResp, err := http.DefaultClient.Do(createReq)
-	require.NoError(t, err)
-	defer func() { _ = createResp.Body.Close() }()
-
-	require.Equal(t, http.StatusCreated, createResp.StatusCode)
-
-	createBody, err := io.ReadAll(createResp.Body)
-	require.NoError(t, err)
-
-	var created struct {
-		Number int64  `json:"number"`
-		Title  string `json:"title"`
-		State  string `json:"state"`
+	// Create
+	createIO, createOut, _ := testIO()
+	createOpts := &issuecreate.CreateOptions{
+		IO:         createIO,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Owner:      env.Owner,
+		Repo:       env.Repo,
+		Title:      "[integration-test] CLI lifecycle test",
+		Body:       "Created by integration test via CreateRun.",
 	}
-	require.NoError(t, json.Unmarshal(createBody, &created))
-	assert.Equal(t, "[integration-test] lifecycle test", created.Title)
-	assert.Equal(t, "open", created.State)
+	err := issuecreate.CreateRun(createOpts)
+	require.NoError(t, err)
+	assert.Contains(t, createOut.String(), "Created issue #")
+	t.Logf("Create: %s", createOut.String())
 
-	t.Logf("Created issue #%d", created.Number)
+	// Extract issue number from output
+	var issueNumber int64
+	_, _ = fmt.Sscanf(createOut.String(), "Created issue #%d", &issueNumber)
+	require.Greater(t, issueNumber, int64(0), "failed to parse issue number")
 
-	// Cleanup: close issue at end
+	// Cleanup: close at end
 	defer func() {
-		closePayload, _ := json.Marshal(map[string]string{"state": "closed"})
-		closeURL := fmt.Sprintf("%s/%d", baseURL, created.Number)
-		closeReq, err := http.NewRequest("PATCH", closeURL, bytes.NewReader(closePayload))
-		if err != nil {
-			t.Logf("Failed to create close request: %v", err)
-			return
-		}
-		closeReq.Header.Set("Authorization", "token "+env.Token)
-		closeReq.Header.Set("Content-Type", "application/json")
-
-		closeResp, err := http.DefaultClient.Do(closeReq)
-		if err != nil {
-			t.Logf("Failed to close issue: %v", err)
-			return
-		}
-		_ = closeResp.Body.Close()
-		t.Logf("Closed issue #%d (HTTP %d)", created.Number, closeResp.StatusCode)
+		closeIO, _, _ := testIO()
+		_ = issueclose.CloseRun(&issueclose.CloseOptions{
+			IO: closeIO, HTTPClient: &http.Client{},
+			Host: env.Host, Token: env.Token,
+			Owner: env.Owner, Repo: env.Repo,
+			Number: issueNumber,
+		})
+		t.Logf("Closed issue #%d", issueNumber)
 	}()
 
-	// View issue
-	viewURL := fmt.Sprintf("%s/%d", baseURL, created.Number)
-	viewReq, err := http.NewRequest("GET", viewURL, nil)
-	require.NoError(t, err)
-	viewReq.Header.Set("Authorization", "token "+env.Token)
-
-	viewResp, err := http.DefaultClient.Do(viewReq)
-	require.NoError(t, err)
-	defer func() { _ = viewResp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, viewResp.StatusCode)
-
-	viewBody, err := io.ReadAll(viewResp.Body)
-	require.NoError(t, err)
-
-	var viewed struct {
-		Number int64  `json:"number"`
-		Title  string `json:"title"`
-	}
-	require.NoError(t, json.Unmarshal(viewBody, &viewed))
-	assert.Equal(t, created.Number, viewed.Number)
-
-	// Add comment
-	commentPayload, _ := json.Marshal(map[string]string{
-		"body": "Integration test comment — will be cleaned up.",
+	// View
+	viewIO, viewOut, _ := testIO()
+	err = issueview.ViewRun(&issueview.ViewOptions{
+		IO: viewIO, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+		Number: issueNumber,
 	})
-	commentURL := fmt.Sprintf("%s/%d/comments", baseURL, created.Number)
-	commentReq, err := http.NewRequest("POST", commentURL, bytes.NewReader(commentPayload))
 	require.NoError(t, err)
-	commentReq.Header.Set("Authorization", "token "+env.Token)
-	commentReq.Header.Set("Content-Type", "application/json")
+	assert.Contains(t, viewOut.String(), "[integration-test] CLI lifecycle test")
+	t.Logf("View: %s", viewOut.String())
 
-	commentResp, err := http.DefaultClient.Do(commentReq)
+	// Comment
+	commentIO, _, _ := testIO()
+	err = issuecomment.CommentRun(&issuecomment.CommentOptions{
+		IO: commentIO, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+		Number: issueNumber,
+		Body:   "Integration test comment via CommentRun.",
+	})
 	require.NoError(t, err)
-	defer func() { _ = commentResp.Body.Close() }()
+	t.Logf("Comment added to #%d", issueNumber)
 
-	assert.Equal(t, http.StatusCreated, commentResp.StatusCode)
+	// Edit title
+	editIO, _, _ := testIO()
+	err = issueedit.EditRun(&issueedit.EditOptions{
+		IO: editIO, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+		Number: issueNumber,
+		Title:  "[integration-test] CLI lifecycle test (edited)",
+	})
+	require.NoError(t, err)
+	t.Logf("Edited issue #%d", issueNumber)
 
-	t.Logf("Added comment to issue #%d", created.Number)
+	// Close
+	closeIO, closeOut, _ := testIO()
+	err = issueclose.CloseRun(&issueclose.CloseOptions{
+		IO: closeIO, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+		Number: issueNumber,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, closeOut.String(), "Closed issue")
+	t.Logf("Close: %s", closeOut.String())
 }
 
 func TestIssue_List(t *testing.T) {
 	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
 
-	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=all&limit=5&type=issues",
-		env.Host, env.Owner, env.Repo)
-	req, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "token "+env.Token)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var issues []struct {
-		Number int64 `json:"number"`
+	opts := &issuelist.ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Owner:      env.Owner,
+		Repo:       env.Repo,
+		State:      "all",
+		Limit:      5,
 	}
-	require.NoError(t, json.Unmarshal(body, &issues))
 
-	t.Logf("Found %d issues", len(issues))
+	err := issuelist.ListRun(opts)
+	require.NoError(t, err)
+	t.Logf("Output: %s", stdout.String())
+}
+
+func TestIssue_ViewNotFound(t *testing.T) {
+	env := loadTestEnv(t)
+	ios, _, _ := testIO()
+
+	err := issueview.ViewRun(&issueview.ViewOptions{
+		IO: ios, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+		Number: 99999,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/test/integration/label_test.go
+++ b/test/integration/label_test.go
@@ -3,96 +3,71 @@
 package integration
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	labelcreate "github.com/qubernetic/copia-cli/pkg/cmd/label/create"
+	labellist "github.com/qubernetic/copia-cli/pkg/cmd/label/list"
 )
 
-func TestLabel_CreateListDelete(t *testing.T) {
+func TestLabel_CreateAndList(t *testing.T) {
 	env := loadTestEnv(t)
-	baseURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/labels", env.Host, env.Owner, env.Repo)
 
-	// Create label
-	createPayload, _ := json.Marshal(map[string]string{
-		"name":        "integration-test-label",
-		"color":       "#ff0000",
-		"description": "Created by integration test",
+	// Create label via CLI
+	createIO, createOut, _ := testIO()
+	err := labelcreate.CreateRun(&labelcreate.CreateOptions{
+		IO: createIO, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+		Name: "integration-test-label", Color: "#ff0000",
 	})
-
-	createReq, err := http.NewRequest("POST", baseURL, bytes.NewReader(createPayload))
 	require.NoError(t, err)
-	createReq.Header.Set("Authorization", "token "+env.Token)
-	createReq.Header.Set("Content-Type", "application/json")
+	assert.Contains(t, createOut.String(), "integration-test-label")
+	t.Logf("Create: %s", createOut.String())
 
-	createResp, err := http.DefaultClient.Do(createReq)
-	require.NoError(t, err)
-	defer func() { _ = createResp.Body.Close() }()
-
-	require.Equal(t, http.StatusCreated, createResp.StatusCode)
-
-	createBody, err := io.ReadAll(createResp.Body)
-	require.NoError(t, err)
-
-	var created struct {
-		ID   int64  `json:"id"`
-		Name string `json:"name"`
-	}
-	require.NoError(t, json.Unmarshal(createBody, &created))
-	assert.Equal(t, "integration-test-label", created.Name)
-	assert.Greater(t, created.ID, int64(0))
-
-	t.Logf("Created label: %s (ID: %d)", created.Name, created.ID)
-
-	// Cleanup: delete label
+	// Cleanup: delete label via API
 	defer func() {
-		deleteURL := fmt.Sprintf("%s/%d", baseURL, created.ID)
-		deleteReq, err := http.NewRequest("DELETE", deleteURL, nil)
+		// Get label ID first
+		listURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/labels", env.Host, env.Owner, env.Repo)
+		req, _ := http.NewRequest("GET", listURL, nil)
+		req.Header.Set("Authorization", "token "+env.Token)
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			t.Logf("Failed to create delete request: %v", err)
 			return
 		}
-		deleteReq.Header.Set("Authorization", "token "+env.Token)
-
-		deleteResp, err := http.DefaultClient.Do(deleteReq)
-		if err != nil {
-			t.Logf("Failed to delete label: %v", err)
-			return
+		defer func() { _ = resp.Body.Close() }()
+		var labels []struct {
+			ID   int64  `json:"id"`
+			Name string `json:"name"`
 		}
-		_ = deleteResp.Body.Close()
-		t.Logf("Deleted label ID: %d (HTTP %d)", created.ID, deleteResp.StatusCode)
+		_ = json.NewDecoder(resp.Body).Decode(&labels)
+		for _, l := range labels {
+			if l.Name == "integration-test-label" {
+				delURL := fmt.Sprintf("%s/%d", listURL, l.ID)
+				delReq, _ := http.NewRequest("DELETE", delURL, nil)
+				delReq.Header.Set("Authorization", "token "+env.Token)
+				delResp, _ := http.DefaultClient.Do(delReq)
+				if delResp != nil {
+					_ = delResp.Body.Close()
+				}
+				t.Logf("Deleted label ID: %d", l.ID)
+			}
+		}
 	}()
 
-	// List labels and verify our label exists
-	listReq, err := http.NewRequest("GET", baseURL, nil)
+	// List labels via CLI
+	listIO, listOut, _ := testIO()
+	err = labellist.ListRun(&labellist.ListOptions{
+		IO: listIO, HTTPClient: &http.Client{},
+		Host: env.Host, Token: env.Token,
+		Owner: env.Owner, Repo: env.Repo,
+	})
 	require.NoError(t, err)
-	listReq.Header.Set("Authorization", "token "+env.Token)
-
-	listResp, err := http.DefaultClient.Do(listReq)
-	require.NoError(t, err)
-	defer func() { _ = listResp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, listResp.StatusCode)
-
-	listBody, err := io.ReadAll(listResp.Body)
-	require.NoError(t, err)
-
-	var labels []struct {
-		Name string `json:"name"`
-	}
-	require.NoError(t, json.Unmarshal(listBody, &labels))
-
-	found := false
-	for _, l := range labels {
-		if l.Name == "integration-test-label" {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "created label not found in list")
+	assert.Contains(t, listOut.String(), "integration-test-label")
+	t.Logf("List: %s", listOut.String())
 }

--- a/test/integration/pr_test.go
+++ b/test/integration/pr_test.go
@@ -3,38 +3,30 @@
 package integration
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	prlist "github.com/qubernetic/copia-cli/pkg/cmd/pr/list"
 )
 
 func TestPR_List(t *testing.T) {
 	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
 
-	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls?state=all&limit=5",
-		env.Host, env.Owner, env.Repo)
-	req, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "token "+env.Token)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var prs []struct {
-		Number int64 `json:"number"`
+	opts := &prlist.ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Owner:      env.Owner,
+		Repo:       env.Repo,
+		State:      "all",
+		Limit:      5,
 	}
-	require.NoError(t, json.Unmarshal(body, &prs))
 
-	t.Logf("Found %d pull requests", len(prs))
+	err := prlist.ListRun(opts)
+	require.NoError(t, err)
+	t.Logf("PRs: %s", stdout.String())
 }

--- a/test/integration/repo_test.go
+++ b/test/integration/repo_test.go
@@ -3,66 +3,89 @@
 package integration
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	repolist "github.com/qubernetic/copia-cli/pkg/cmd/repo/list"
+	repoview "github.com/qubernetic/copia-cli/pkg/cmd/repo/view"
+	"github.com/qubernetic/copia-cli/pkg/cmdutil"
 )
 
-func TestRepo_ListUserRepos(t *testing.T) {
+func TestRepoList_Run(t *testing.T) {
 	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
 
-	url := fmt.Sprintf("https://%s/api/v1/user/repos?limit=5", env.Host)
-	req, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "token "+env.Token)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var repos []struct {
-		FullName string `json:"full_name"`
+	opts := &repolist.ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Limit:      5,
 	}
-	require.NoError(t, json.Unmarshal(body, &repos))
-	assert.NotEmpty(t, repos)
 
-	t.Logf("Found %d repos", len(repos))
+	err := repolist.ListRun(opts)
+	require.NoError(t, err)
+	assert.NotEmpty(t, stdout.String())
+	t.Logf("Output: %s", stdout.String())
 }
 
-func TestRepo_ViewTestRepo(t *testing.T) {
+func TestRepoList_JSON(t *testing.T) {
 	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
 
-	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s", env.Host, env.Owner, env.Repo)
-	req, err := http.NewRequest("GET", url, nil)
-	require.NoError(t, err)
-	req.Header.Set("Authorization", "token "+env.Token)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer func() { _ = resp.Body.Close() }()
-
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	var repo struct {
-		FullName      string `json:"full_name"`
-		DefaultBranch string `json:"default_branch"`
+	opts := &repolist.ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Limit:      2,
+		JSON:       cmdutil.JSONFlags{Fields: []string{"full_name"}},
 	}
-	require.NoError(t, json.Unmarshal(body, &repo))
-	assert.Contains(t, repo.FullName, env.Repo)
-	assert.NotEmpty(t, repo.DefaultBranch)
 
-	t.Logf("Repo: %s (default branch: %s)", repo.FullName, repo.DefaultBranch)
+	err := repolist.ListRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "full_name")
+	t.Logf("Output: %s", stdout.String())
+}
+
+func TestRepoView_Run(t *testing.T) {
+	env := loadTestEnv(t)
+	ios, stdout, _ := testIO()
+
+	opts := &repoview.ViewOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Owner:      env.Owner,
+		Repo:       env.Repo,
+	}
+
+	err := repoview.ViewRun(opts)
+	require.NoError(t, err)
+	output := stdout.String()
+	assert.Contains(t, output, env.Owner+"/"+env.Repo)
+	assert.Contains(t, output, "Default branch")
+	t.Logf("Output: %s", output)
+}
+
+func TestRepoView_NotFound(t *testing.T) {
+	env := loadTestEnv(t)
+	ios, _, _ := testIO()
+
+	opts := &repoview.ViewOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{},
+		Host:       env.Host,
+		Token:      env.Token,
+		Owner:      "nonexistent-org-xyz",
+		Repo:       "nonexistent-repo-xyz",
+	}
+
+	err := repoview.ViewRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }


### PR DESCRIPTION
## Summary

Closes #103

### Changes

1. **Export Run functions** (34 files): `listRun` → `ListRun` etc. so integration tests can call them
2. **Rewrite integration tests** (6 files): Replace direct HTTP API calls with `*Run()` function calls

### What's tested

| Test | CLI functions exercised |
|------|------------------------|
| TestAuth_LoginRun_ValidToken | `login.LoginRun` |
| TestAuth_LoginRun_InvalidToken | `login.LoginRun` (error path) |
| TestAuth_StatusRun | `status.StatusRun` |
| TestIssue_FullLifecycle | `CreateRun`, `ViewRun`, `CommentRun`, `EditRun`, `CloseRun` |
| TestIssue_List | `issuelist.ListRun` |
| TestIssue_ViewNotFound | `ViewRun` (error path) |
| TestLabel_CreateAndList | `labelcreate.CreateRun`, `labellist.ListRun` |
| TestPR_List | `prlist.ListRun` |
| TestRepoList_Run | `repolist.ListRun` |
| TestRepoList_JSON | `repolist.ListRun` (JSON output) |
| TestRepoView_Run | `repoview.ViewRun` |
| TestRepoView_NotFound | `repoview.ViewRun` (error path) |

### Bug detection validated

Reintroduced bugs #100 and #102 temporarily — tests correctly FAIL:
- `_ = resp.Body.Close()` → FAIL: `file already closed`
- `StatusOK` only → FAIL: `failed to close issue (HTTP 201)`

## Test plan

- [x] All 12 integration tests pass locally
- [x] All unit tests pass (`go test ./...`)
- [x] Bug detection validated (reintroduced #100, #102 → tests FAIL)