### PR TITLE
fix: validate --state flag values in issue list and pr list (#106)

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -78,6 +78,12 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func ListRun(opts *ListOptions) error {
+	switch opts.State {
+	case "open", "closed", "all":
+	default:
+		return fmt.Errorf("invalid state %q: valid values are {open|closed|all}", opts.State)
+	}
+
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=%s&limit=%d&type=issues",
 		opts.Host, opts.Owner, opts.Repo, opts.State, opts.Limit)
 

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestListRun_InvalidState(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &ListOptions{
+		IO:    ios,
+		State: "invalid",
+	}
+
+	err := ListRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid state")
+}
+
 func TestListRun_Success(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -84,6 +84,12 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func ListRun(opts *ListOptions) error {
+	switch opts.State {
+	case "open", "closed", "merged", "all":
+	default:
+		return fmt.Errorf("invalid state %q: valid values are {open|closed|merged|all}", opts.State)
+	}
+
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls?state=%s&limit=%d",
 		opts.Host, opts.Owner, opts.Repo, opts.State, opts.Limit)
 

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestListRun_InvalidState(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &ListOptions{
+		IO:    ios,
+		State: "invalid",
+	}
+
+	err := ListRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid state")
+}
+
 func TestListRun_Success(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)


### PR DESCRIPTION
## Summary

Closes #106

Reject invalid `--state` values with a clear error message, matching `gh` CLI behavior.

- `issue list --state`: accepts `open`, `closed`, `all`
- `pr list --state`: accepts `open`, `closed`, `merged`, `all`

```
$ copia-cli issue list --state invalid
Error: invalid state "invalid": valid values are {open|closed|all}
```

## Test plan

- [x] Unit tests for invalid state (issue list + pr list)
- [x] All existing tests pass