### PR TITLE
feat: validate --limit flag rejects negative and zero values (#110)

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -78,6 +78,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func ListRun(opts *ListOptions) error {
+	if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+		return err
+	}
+
 	switch opts.State {
 	case "open", "closed", "all":
 	default:

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -17,6 +17,7 @@ func TestListRun_InvalidState(t *testing.T) {
 	opts := &ListOptions{
 		IO:    ios,
 		State: "invalid",
+		Limit: 30,
 	}
 
 	err := ListRun(opts)

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -84,6 +84,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func ListRun(opts *ListOptions) error {
+	if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+		return err
+	}
+
 	switch opts.State {
 	case "open", "closed", "merged", "all":
 	default:

--- a/pkg/cmd/pr/list/list_test.go
+++ b/pkg/cmd/pr/list/list_test.go
@@ -17,6 +17,7 @@ func TestListRun_InvalidState(t *testing.T) {
 	opts := &ListOptions{
 		IO:    ios,
 		State: "invalid",
+		Limit: 30,
 	}
 
 	err := ListRun(opts)

--- a/pkg/cmd/release/list/list.go
+++ b/pkg/cmd/release/list/list.go
@@ -70,6 +70,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func ListRun(opts *ListOptions) error {
+	if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+		return err
+	}
+
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/releases?limit=%d",
 		opts.Host, opts.Owner, opts.Repo, opts.Limit)
 

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -64,6 +64,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 }
 
 func ListRun(opts *ListOptions) error {
+	if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+		return err
+	}
+
 	endpoint := "/api/v1/user/repos"
 	if opts.Org != "" {
 		endpoint = fmt.Sprintf("/api/v1/orgs/%s/repos", opts.Org)

--- a/pkg/cmd/repo/list/list_test.go
+++ b/pkg/cmd/repo/list/list_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestListRun_InvalidLimit(t *testing.T) {
+	ios, _, _, _ := iostreams.Test()
+
+	opts := &ListOptions{
+		IO:    ios,
+		Limit: -1,
+	}
+
+	err := ListRun(opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid limit")
+}
+
 func TestListRun_UserRepos(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -74,6 +74,10 @@ func NewCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 }
 
 func SearchRun(opts *SearchOptions) error {
+	if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+		return err
+	}
+
 	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?q=%s&limit=%d&type=issues",
 		opts.Host, opts.Owner, opts.Repo, url.QueryEscape(opts.Query), opts.Limit)
 	if opts.State != "" {

--- a/pkg/cmd/search/repos/repos.go
+++ b/pkg/cmd/search/repos/repos.go
@@ -66,6 +66,10 @@ func NewCmdSearchRepos(f *cmdutil.Factory) *cobra.Command {
 }
 
 func SearchRun(opts *SearchOptions) error {
+	if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+		return err
+	}
+
 	u := fmt.Sprintf("https://%s/api/v1/repos/search?q=%s&limit=%d",
 		opts.Host, url.QueryEscape(opts.Query), opts.Limit)
 

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -75,3 +75,11 @@ func (f *Factory) ResolveRepo() (owner, repo string, err error) {
 	}
 	return f.BaseRepo()
 }
+
+// ValidateLimit returns an error if limit is not a positive integer.
+func ValidateLimit(limit int) error {
+	if limit < 1 {
+		return fmt.Errorf("invalid limit: %d", limit)
+	}
+	return nil
+}

--- a/pkg/cmdutil/factory_test.go
+++ b/pkg/cmdutil/factory_test.go
@@ -143,6 +143,23 @@ func TestFactory_ResolveRepo_InvalidFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected owner/repo format")
 }
 
+func TestValidateLimit_Valid(t *testing.T) {
+	assert.NoError(t, ValidateLimit(1))
+	assert.NoError(t, ValidateLimit(100))
+}
+
+func TestValidateLimit_Zero(t *testing.T) {
+	err := ValidateLimit(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid limit")
+}
+
+func TestValidateLimit_Negative(t *testing.T) {
+	err := ValidateLimit(-1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid limit")
+}
+
 func TestParseRemoteURL_HTTPS(t *testing.T) {
 	owner, repo, err := ParseRemoteURL("https://app.copia.io/my-org/my-repo.git")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary

Closes #110

Add `cmdutil.ValidateLimit()` helper, applied to all 6 commands with `--limit`:
repo list, issue list, pr list, release list, search repos, search issues.

```
$ copia-cli repo list --limit -1
Error: invalid limit: -1
```

## Test plan

- [x] Unit tests for ValidateLimit (valid, zero, negative)
- [x] Command-level test for repo list --limit -1
- [x] All existing tests pass