### PR TITLE
feat: add issue list --label flag for filtering by label (#111)

### DIFF
--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -24,6 +25,7 @@ type ListOptions struct {
 	Repo       string
 	State      string
 	Limit      int
+	Labels     []string
 	JSON       cmdutil.JSONFlags
 }
 
@@ -72,6 +74,7 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.State, "state", "s", "open", "Filter by state: {open|closed|all}")
 	cmd.Flags().IntVarP(&opts.Limit, "limit", "L", 30, "Maximum number of issues")
+	cmd.Flags().StringSliceVarP(&opts.Labels, "label", "l", nil, "Filter by label")
 	cmdutil.AddJSONFlags(cmd, &opts.JSON, validJSONFields)
 
 	return cmd
@@ -88,10 +91,13 @@ func ListRun(opts *ListOptions) error {
 		return fmt.Errorf("invalid state %q: valid values are {open|closed|all}", opts.State)
 	}
 
-	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=%s&limit=%d&type=issues",
+	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?state=%s&limit=%d&type=issues",
 		opts.Host, opts.Owner, opts.Repo, opts.State, opts.Limit)
+	if len(opts.Labels) > 0 {
+		u += "&labels=" + strings.Join(opts.Labels, ",")
+	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/issue/list/list_test.go
+++ b/pkg/cmd/issue/list/list_test.go
@@ -85,3 +85,33 @@ func TestListRun_JSON(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), `"number"`)
 }
+
+func TestListRun_LabelFilter(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/repos/my-org/my-repo/issues"),
+		httpmock.StringResponse(http.StatusOK, `[
+			{"number":12,"title":"Fix PLC timeout","state":"open","updated_at":"2026-03-30T10:00:00Z","labels":[{"name":"bug"}]}
+		]`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "my-repo",
+		State:      "open",
+		Limit:      30,
+		Labels:     []string{"bug"},
+	}
+
+	err := ListRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Fix PLC timeout")
+}


### PR DESCRIPTION
## Summary

Closes #111

Add `--label`/`-l` flag to `issue list` for filtering issues by label name, matching `gh` CLI behavior.

```
$ copia-cli issue list --label bug
$ copia-cli issue list -l bug -l urgent
```

Passes label names to Gitea API as `?labels=name1,name2`.

## Test plan

- [x] Unit test for label filter
- [x] All existing tests pass