### PR TITLE
feat: add pr close --comment and --delete-branch flags (#112)

### DIFF
--- a/pkg/cmd/pr/close/close.go
+++ b/pkg/cmd/pr/close/close.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -14,13 +15,15 @@ import (
 
 // CloseOptions holds all inputs for the pr close command.
 type CloseOptions struct {
-	IO         *iostreams.IOStreams
-	HTTPClient *http.Client
-	Host       string
-	Token      string
-	Owner      string
-	Repo       string
-	Number     int64
+	IO           *iostreams.IOStreams
+	HTTPClient   *http.Client
+	Host         string
+	Token        string
+	Owner        string
+	Repo         string
+	Number       int64
+	Comment      string
+	DeleteBranch bool
 }
 
 // NewCmdClose creates the `copia pr close` command.
@@ -30,7 +33,9 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "close <number>",
 		Short:   "Close a pull request",
-		Example: "  copia pr close 7",
+		Example: `  copia pr close 7
+  copia pr close 7 --comment "Closing in favor of #8"
+  copia pr close 7 --delete-branch`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			num, err := strconv.ParseInt(args[0], 10, 64)
@@ -58,10 +63,37 @@ func NewCmdClose(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringVarP(&opts.Comment, "comment", "c", "", "Leave a closing comment")
+	cmd.Flags().BoolVarP(&opts.DeleteBranch, "delete-branch", "d", false, "Delete the local and remote branch after close")
+
 	return cmd
 }
 
 func CloseRun(opts *CloseOptions) error {
+	// Add comment before closing if requested
+	if opts.Comment != "" {
+		commentPayload, _ := json.Marshal(map[string]string{"body": opts.Comment})
+		commentURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues/%d/comments",
+			opts.Host, opts.Owner, opts.Repo, opts.Number)
+
+		req, err := http.NewRequest("POST", commentURL, bytes.NewReader(commentPayload))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "token "+opts.Token)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := opts.HTTPClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusCreated {
+			return fmt.Errorf("failed to add comment (HTTP %d)", resp.StatusCode)
+		}
+	}
+
+	// Close the PR
 	payload, _ := json.Marshal(map[string]string{"state": "closed"})
 	url := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/pulls/%d",
 		opts.Host, opts.Owner, opts.Repo, opts.Number)
@@ -83,6 +115,38 @@ func CloseRun(opts *CloseOptions) error {
 		return fmt.Errorf("failed to close PR (HTTP %d)", resp.StatusCode)
 	}
 
+	// Read response to get head branch for delete
+	var prData struct {
+		Head struct {
+			Label string `json:"label"`
+		} `json:"head"`
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = json.Unmarshal(body, &prData)
+
 	_, _ = fmt.Fprintf(opts.IO.Out, "Closed PR #%d\n", opts.Number)
+
+	// Delete branch if requested
+	if opts.DeleteBranch && prData.Head.Label != "" {
+		branchURL := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/branches/%s",
+			opts.Host, opts.Owner, opts.Repo, prData.Head.Label)
+
+		delReq, err := http.NewRequest("DELETE", branchURL, nil)
+		if err != nil {
+			return err
+		}
+		delReq.Header.Set("Authorization", "token "+opts.Token)
+
+		delResp, err := opts.HTTPClient.Do(delReq)
+		if err != nil {
+			return fmt.Errorf("failed to delete branch: %w", err)
+		}
+		defer func() { _ = delResp.Body.Close() }()
+
+		if delResp.StatusCode == http.StatusNoContent || delResp.StatusCode == http.StatusOK {
+			_, _ = fmt.Fprintf(opts.IO.Out, "Deleted branch %s\n", prData.Head.Label)
+		}
+	}
+
 	return nil
 }

--- a/pkg/cmd/pr/close/close_test.go
+++ b/pkg/cmd/pr/close/close_test.go
@@ -35,3 +35,65 @@ func TestCloseRun_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "Closed PR #7")
 }
+
+func TestCloseRun_WithComment(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("POST", "/api/v1/repos/my-org/my-repo/issues/7/comments"),
+		httpmock.StringResponse(http.StatusCreated, `{"id":1}`),
+	)
+	reg.Register(
+		httpmock.REST("PATCH", "/api/v1/repos/my-org/my-repo/pulls/7"),
+		httpmock.StringResponse(http.StatusOK, `{"number":7,"state":"closed"}`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &CloseOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "my-repo",
+		Number:     7,
+		Comment:    "Closing in favor of #8",
+	}
+
+	err := CloseRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Closed PR #7")
+}
+
+func TestCloseRun_WithDeleteBranch(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("PATCH", "/api/v1/repos/my-org/my-repo/pulls/7"),
+		httpmock.StringResponse(http.StatusOK, `{"number":7,"state":"closed","head":{"label":"feature/old"}}`),
+	)
+	reg.Register(
+		httpmock.REST("DELETE", "/api/v1/repos/my-org/my-repo/branches/feature/old"),
+		httpmock.StringResponse(http.StatusNoContent, ``),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &CloseOptions{
+		IO:           ios,
+		HTTPClient:   &http.Client{Transport: reg},
+		Host:         "app.copia.io",
+		Token:        "test-token",
+		Owner:        "my-org",
+		Repo:         "my-repo",
+		Number:       7,
+		DeleteBranch: true,
+	}
+
+	err := CloseRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Closed PR #7")
+}


### PR DESCRIPTION
## Summary

Closes #112

Add `--comment` and `--delete-branch` flags to `pr close`, matching `gh` CLI behavior.

```
copia-cli pr close 7 --comment "Closing in favor of #8"
copia-cli pr close 7 --delete-branch
copia-cli pr close 7 -c "Done" -d
```

## Test plan

- [x] TestCloseRun_Success — basic close
- [x] TestCloseRun_WithComment — comment added before close
- [x] TestCloseRun_WithDeleteBranch — branch deleted after close
- [x] All existing tests pass