### PR TITLE
fix: search issues defaults to all states instead of open only (#108)

### DIFF
--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -78,11 +78,13 @@ func SearchRun(opts *SearchOptions) error {
 		return err
 	}
 
-	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?q=%s&limit=%d&type=issues",
-		opts.Host, opts.Owner, opts.Repo, url.QueryEscape(opts.Query), opts.Limit)
-	if opts.State != "" {
-		u += "&state=" + url.QueryEscape(opts.State)
+	state := opts.State
+	if state == "" {
+		state = "all"
 	}
+
+	u := fmt.Sprintf("https://%s/api/v1/repos/%s/%s/issues?q=%s&limit=%d&type=issues&state=%s",
+		opts.Host, opts.Owner, opts.Repo, url.QueryEscape(opts.Query), opts.Limit, url.QueryEscape(state))
 
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {

--- a/pkg/cmd/search/issues/issues_test.go
+++ b/pkg/cmd/search/issues/issues_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSearchIssues_DefaultStateAll(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/repos/my-org/plc/issues"),
+		httpmock.StringResponse(http.StatusOK, `[
+			{"number":5,"title":"Closed issue","state":"closed"}
+		]`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &SearchOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		Owner:      "my-org",
+		Repo:       "plc",
+		Query:      "issue",
+		Limit:      30,
+		// State intentionally empty — should default to "all"
+	}
+
+	err := SearchRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Closed issue")
+}
+
 func TestSearchIssues_Success(t *testing.T) {
 	reg := &httpmock.Registry{}
 	defer reg.Verify(t)


### PR DESCRIPTION
## Summary

Closes #108

### Root cause

The Gitea API defaults to `state=open` when no state parameter is given. The `search issues` command didn't set a default, so it only searched open issues — returning empty results when matching issues were closed.

### Fix

Default `state` to `all` when not explicitly specified, so search finds issues in any state (matching `gh search issues` behavior).

### Investigation

```
copia-cli api "/repos/.../issues?q=test&type=issues"          → []
copia-cli api "/repos/.../issues?q=test&type=issues&state=all" → [results]
```

## Test plan

- [x] TestSearchIssues_DefaultStateAll — empty state defaults to all
- [x] All existing tests pass