### PR TITLE
fix: notification list HTTP 500 and add --all flag (#109)

### DIFF
--- a/pkg/cmd/notification/list/list.go
+++ b/pkg/cmd/notification/list/list.go
@@ -17,6 +17,7 @@ type ListOptions struct {
 	HTTPClient *http.Client
 	Host       string
 	Token      string
+	All        bool
 	JSON       cmdutil.JSONFlags
 }
 
@@ -57,12 +58,16 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&opts.All, "all", false, "Show read and unread notifications")
 	cmdutil.AddJSONFlags(cmd, &opts.JSON, []string{"id", "subject", "repository", "unread"})
 	return cmd
 }
 
 func ListRun(opts *ListOptions) error {
-	url := fmt.Sprintf("https://%s/api/v1/notifications", opts.Host)
+	url := fmt.Sprintf("https://%s/api/v1/notifications?page=1", opts.Host)
+	if opts.All {
+		url += "&all=true"
+	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err

--- a/pkg/cmd/notification/list/list_test.go
+++ b/pkg/cmd/notification/list/list_test.go
@@ -36,3 +36,52 @@ func TestListRun_Success(t *testing.T) {
 	assert.Contains(t, stdout.String(), "Fix PLC timeout")
 	assert.Contains(t, stdout.String(), "Add sensor")
 }
+
+func TestListRun_Empty(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/notifications"),
+		httpmock.StringResponse(http.StatusOK, `[]`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+	}
+
+	err := ListRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No unread notifications")
+}
+
+func TestListRun_AllFlag(t *testing.T) {
+	reg := &httpmock.Registry{}
+	defer reg.Verify(t)
+
+	reg.Register(
+		httpmock.REST("GET", "/api/v1/notifications"),
+		httpmock.StringResponse(http.StatusOK, `[
+			{"id":1,"subject":{"title":"Old PR","type":"Pull"},"repository":{"full_name":"my-org/plc"},"unread":false}
+		]`),
+	)
+
+	ios, _, stdout, _ := iostreams.Test()
+
+	opts := &ListOptions{
+		IO:         ios,
+		HTTPClient: &http.Client{Transport: reg},
+		Host:       "app.copia.io",
+		Token:      "test-token",
+		All:        true,
+	}
+
+	err := ListRun(opts)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Old PR")
+}


### PR DESCRIPTION
## Summary

Closes #109

### Root cause

Copia/Gitea returns HTTP 500 on `GET /api/v1/notifications` without any query parameters. Adding `?page=1` works around this server-side bug.

### Additional fix

Added `--all` flag to show both read and unread notifications (passes `?all=true` to API). Without this flag, only unread notifications are shown (Gitea default).

### Investigation

```
GET /notifications           → 500
GET /notifications?page=1    → 200 (unread only)
GET /notifications?page=1&all=true → 200 (all notifications)
```

## Test plan

- [x] TestListRun_Success — list unread notifications
- [x] TestListRun_Empty — empty list message
- [x] TestListRun_AllFlag — --all shows read notifications
- [x] All existing tests pass