### PR TITLE
fix: update binary name references in docs (#140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Follows the `gh` CLI repository structure (`github.com/cli/cli`).
 
 ```
 copia-cli/
-├── cmd/copia/              # Entrypoint
+├── cmd/copia-cli/          # Entrypoint
 ├── internal/
 │   ├── build/              # Version injection (ldflags)
 │   ├── config/             # Config & auth management

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ npx @devcontainers/cli up --workspace-folder .
 # Run commands inside the container
 npx @devcontainers/cli exec --workspace-folder . make build
 npx @devcontainers/cli exec --workspace-folder . make test
-npx @devcontainers/cli exec --workspace-folder . ./bin/copia --version
+npx @devcontainers/cli exec --workspace-folder . ./bin/copia-cli --version
 ```
 
 > **Note:** `npx` runs the devcontainer CLI without global installation. Install globally with `npm install -g @devcontainers/cli` to use `devcontainer` directly.
@@ -103,7 +103,7 @@ make integration
 ## Project Structure
 
 ```
-cmd/copia/          Entrypoint
+cmd/copia-cli/      Entrypoint
 internal/           Private packages (config, build, root command)
 pkg/cmd/            Command packages (one per command group)
   auth/             login, logout, status
@@ -144,4 +144,4 @@ Please open an issue with:
 - The command you ran
 - What happened (include error output)
 - What you expected to happen
-- Your OS and `copia --version` output
+- Your OS and `copia-cli --version` output

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ Please include:
 
 - A description of the issue and its potential impact
 - Steps to reproduce or a scenario demonstrating the problem
-- Your OS and `copia --version` output
+- Your OS and `copia-cli --version` output
 
 ## Response Timeline
 

--- a/docs/cli-patterns.md
+++ b/docs/cli-patterns.md
@@ -725,7 +725,7 @@ Apply these patterns:
 
 - ✓ Create `pkg/cmdutil/factory.go` with Gitea-specific clients
 - ✓ Create `pkg/iostreams/iostreams.go` for terminal abstraction
-- ✓ Create `cmd/copia/main.go` → `internal/giteacmd/main.go`
+- ✓ Create `cmd/copia-cli/main.go` → `internal/copiacmd/main.go`
 - ✓ Each command: `*Options` struct + `NewCmd*()` + `*Run()` function
 - ✓ Use `github.com/spf13/cobra` for CLI skeleton
 - ✓ Create `pkg/httpmock/` adapter for Gitea API mocking

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -13,7 +13,7 @@ total_tokens: 104574
 ```mermaid
 graph TB
     subgraph Entrypoint
-        main[cmd/copia/main.go]
+        main[cmd/copia-cli/main.go]
     end
     subgraph Internal
         copiacmd[copiacmd.Main]
@@ -58,7 +58,7 @@ graph TB
 
 ```
 copia-cli/
-├── cmd/copia/main.go              # Entrypoint → copiacmd.Main()
+├── cmd/copia-cli/main.go              # Entrypoint → copiacmd.Main()
 ├── internal/
 │   ├── build/build.go             # Version/Date injection (ldflags)
 │   ├── config/config.go           # YAML config (~/.config/copia/config.yml)
@@ -86,7 +86,7 @@ copia-cli/
 
 ## Module Guide
 
-### `cmd/copia/`
+### `cmd/copia-cli/`
 **Purpose:** Binary entrypoint — delegates to `copiacmd.Main()`
 **Entry point:** `main.go`
 

--- a/internal/copiacmd/root.go
+++ b/internal/copiacmd/root.go
@@ -55,7 +55,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-// Main is the entrypoint called from cmd/copia/main.go.
+// Main is the entrypoint called from cmd/copia-cli/main.go.
 func Main() int {
 	ios := iostreams.System()
 


### PR DESCRIPTION
## Summary

Closes #140

Fix stale `copia` references that should be `copia-cli` after the binary rename in v0.4.0-rc.1.

### Files fixed
- `CLAUDE.md` — `cmd/copia/` → `cmd/copia-cli/`
- `CONTRIBUTING.md` — `cmd/copia/`, `./bin/copia`, `copia --version`
- `SECURITY.md` — `copia --version`
- `docs/project-layout.md` — `cmd/copia/` (3 occurrences)
- `docs/cli-patterns.md` — `cmd/copia/main.go` + legacy `giteacmd`
- `internal/copiacmd/root.go` — comment