### PR TITLE
chore: audit fixes — security email, roadmap, CI permissions (#141, #142, #143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ docs/site/manual/copia-cli_*.md
 desktop.ini
 thumbs.db
 
+# Secrets
+.env*
+
 # Test
 *.test
 coverage.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Copia CLI is a command-line interface for [Copia](https://copia.io) — the source control platform for industrial automation. Modeled after GitHub CLI (`gh`), built on the Gitea-compatible REST API. Phase 1 (MVP) and Phase 2 (Workflow) are complete with 30+ subcommands across 7 command groups.
+Copia CLI is a command-line interface for [Copia](https://copia.io) — the source control platform for industrial automation. Modeled after GitHub CLI (`gh`), built on the Gitea-compatible REST API. Phase 1-3 complete with 35+ subcommands across 11 command groups.
 
 **Owner:** Qubernetic (AGPL-3.0 + Commercial)
 
@@ -64,7 +64,7 @@ copia-cli/
 
 Phase 1 (MVP): auth, repo list/view/clone, issue CRUD, pr CRUD, label list/create — **DONE**
 Phase 2: release CRUD, repo create/delete/fork, pr review/diff/checkout, issue edit, Homebrew tap — **DONE**
-Phase 3: generic `copia-cli api` escape hatch, search, orgs, notifications, tab completion
+Phase 3: `copia-cli api` escape hatch, search, orgs, notifications, `-R` flag, completion, Jekyll manual, AGPL license — **DONE**
 Phase 4: winget, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks, changelog, collaborators
 
 **Out of scope:** workflow/run, codespace, copilot, project, cache, GUI

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -20,9 +20,9 @@ A commercial license is required if you want to:
 
 For commercial licensing inquiries, please contact:
 
-**Csaba Attila Biró**
-Email: csaba.biro@qubernetic.io
-GitHub: [@q-soriarty](https://github.com/q-soriarty)
+**Qubernetic**
+Email: info@qubernetic.com
+Web: [github.com/qubernetic](https://github.com/qubernetic)
 
 ## FAQ
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ clean:
 snapshot:
 	goreleaser release --snapshot --clean
 
-install:
+install: ## Install rpm (Fedora/RHEL only)
 	sudo dnf install -y dist/$(BIN)_*_linux_amd64.rpm
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ $ copia-cli pr merge 7 --merge --delete-branch
 
 - **Phase 1 (MVP):** auth, repo list/view/clone, issue CRUD, pr CRUD, label list/create — **Done**
 - **Phase 2 (Workflow):** release CRUD, repo create/delete/fork, pr review/diff/checkout, issue edit, Homebrew tap — **Done**
-- **Phase 3 (Power Features):** generic `api` escape hatch, search, orgs, notifications, `-R` flag, tab completion, Jekyll manual — **In progress**
-- **Phase 4 (Nice to Have):** winget, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks
+- **Phase 3 (Power Features):** `api` escape hatch, search, orgs, notifications, `-R`/`--repo` flag, completion, Jekyll manual, AGPL license — **Done**
+- **Phase 4 (Nice to Have):** winget, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks, scheduled integration tests
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ If you discover any of the above, or any other security-relevant behavior, pleas
 Instead, use one of the following:
 
 - **GitHub Security Advisories**: Report privately via [GitHub's Security Advisory feature](https://github.com/qubernetic/copia-cli/security/advisories/new) on this repository.
-- **Email**: Send a detailed report to **[INSERT SECURITY EMAIL]**.
+- **Email**: Send a detailed report to **info@qubernetic.com**.
 
 Please include:
 


### PR DESCRIPTION
## Summary

Closes #141
Closes #142
Closes #143

### Fix: SECURITY.md placeholder email (#141)
- Replace `[INSERT SECURITY EMAIL]` with `info@qubernetic.com`
- Generalize LICENSE-COMMERCIAL.md contact to Qubernetic

### Docs: update roadmap (#142)
- README.md and CLAUDE.md: Phase 3 marked as Done
- Command count updated to 35+ across 11 groups

### Chore: CI and config (#143)
- ci.yml: add `permissions: { contents: read }` for least-privilege
- .gitignore: add `.env*` exclusion
- Makefile: add comment noting dnf dependency