### PR TITLE
docs: enrich command Long descriptions with filtering details (#138)

### DIFF
--- a/pkg/cmd/api/api.go
+++ b/pkg/cmd/api/api.go
@@ -32,7 +32,14 @@ func NewCmdAPI(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "api <path>",
 		Short: "Make an API request",
-		Long:  "Make an authenticated HTTP request to the Copia REST API and print the response. The endpoint argument should be a path of a Gitea API v1 endpoint.",
+		Long: `Make an authenticated HTTP request to the Copia REST API and print the response.
+
+The endpoint argument should be a path of a Gitea API v1 endpoint. The /api/v1
+prefix is added automatically if not present.
+
+Use --field to send JSON body fields (automatically switches to POST method).
+Use --method to override the HTTP method (GET, POST, PATCH, DELETE, PUT).
+Use --header to add custom HTTP headers.`,
 		Example: `  # Get authenticated user
   $ copia-cli api /user
 

--- a/pkg/cmd/auth/login/login.go
+++ b/pkg/cmd/auth/login/login.go
@@ -30,7 +30,12 @@ func NewCmdLogin(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with a Copia instance",
-		Long:  "Authenticate with a Copia host. The default authentication mode is interactive, prompting for host and token. Use --host and --token for non-interactive login in CI environments.",
+		Long: `Authenticate with a Copia host. The default hostname is app.copia.io.
+
+The default authentication mode is interactive, prompting for a token.
+Use --host and --token for non-interactive login in CI environments.
+
+Token precedence: --token flag > COPIA_TOKEN env var > config file.`,
 		Example: `  # Interactive login
   $ copia-cli auth login
 

--- a/pkg/cmd/issue/list/list.go
+++ b/pkg/cmd/issue/list/list.go
@@ -48,7 +48,11 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List issues in a repository",
-		Long:    "List issues in a Copia repository. By default, only open issues are listed.",
+		Long: `List issues in a Copia repository. By default, only open issues are listed.
+
+Use --state to filter by open, closed, or all states.
+Use --label to filter by one or more label names.
+Use --limit to control how many issues are returned (default 30).`,
 		Aliases: []string{"ls"},
 		Example: `  $ copia-cli issue list
   $ copia-cli issue list --state closed

--- a/pkg/cmd/pr/list/list.go
+++ b/pkg/cmd/pr/list/list.go
@@ -52,7 +52,10 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List pull requests",
-		Long:    "List pull requests in a Copia repository. By default, only open pull requests are listed.",
+		Long: `List pull requests in a Copia repository. By default, only open pull requests are listed.
+
+Use --state to filter by open, closed, merged, or all states.
+Use --limit to control how many pull requests are returned (default 30).`,
 		Aliases: []string{"ls"},
 		Example: `  $ copia-cli pr list
   $ copia-cli pr list --state closed

--- a/pkg/cmd/repo/clone/clone.go
+++ b/pkg/cmd/repo/clone/clone.go
@@ -27,7 +27,9 @@ func NewCmdClone(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clone <owner/repo | URL> [<directory>]",
 		Short: "Clone a repository",
-		Long:  "Clone a Copia repository locally. The repository can be specified as owner/repo or as a full URL.",
+		Long: `Clone a Copia repository locally. The repository can be specified as
+owner/repo or as a full URL. Private repositories are automatically
+authenticated using your configured token.`,
 		Example: `  # Clone by owner/repo
   $ copia-cli repo clone my-org/my-repo
 

--- a/pkg/cmd/repo/list/list.go
+++ b/pkg/cmd/repo/list/list.go
@@ -39,7 +39,8 @@ func NewCmdList(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List repositories",
-		Long:    "List repositories owned by the authenticated user or a specified organization.",
+		Long: `List repositories owned by the authenticated user. Use --org to list
+repositories for a specific organization instead.`,
 		Aliases: []string{"ls"},
 		Example: `  $ copia-cli repo list
   $ copia-cli repo list --org my-org

--- a/pkg/cmd/search/issues/issues.go
+++ b/pkg/cmd/search/issues/issues.go
@@ -40,7 +40,9 @@ func NewCmdSearchIssues(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "issues <query>",
 		Short: "Search issues in a repository",
-		Long:  "Search issues within the current repository. Requires repo context (git remote or owner/repo argument).",
+		Long: `Search issues within a repository by keyword. By default, searches across
+all states (open and closed). Use --state to filter. Requires repo context
+via -R flag or git remote.`,
 		Example: `  $ copia-cli search issues "sensor timeout"
   $ copia-cli search issues bug --state closed`,
 		Args: cobra.ExactArgs(1),


### PR DESCRIPTION
## Summary

Closes #138

Expanded Long descriptions for key commands with filtering options and behavior details.

### Commands enriched
- **issue list**: --state, --label, --limit documentation
- **pr list**: --state (including merged), --limit
- **repo list**: --org behavior
- **repo clone**: private repo auth behavior
- **search issues**: state=all default, -R flag requirement
- **api**: endpoint format, --field, --method, --header usage
- **auth login**: token precedence (flag > env > config)

## Test plan
- [x] All tests pass
- [x] `go build ./...` clean