### PR TITLE
feat: enrich version command with Go version and OS/arch (#150)

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,6 +1,10 @@
 package build
 
-import "runtime/debug"
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+)
 
 // Version is set at build time via ldflags.
 var Version = "DEV"
@@ -14,4 +18,14 @@ func init() {
 			Version = info.Main.Version
 		}
 	}
+}
+
+// VersionInfo returns a formatted version string with build details.
+func VersionInfo() string {
+	version := fmt.Sprintf("copia-cli version %s", Version)
+	if Date != "" {
+		version += fmt.Sprintf(" (%s)", Date)
+	}
+	version += fmt.Sprintf("\ngo: %s\nos/arch: %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	return version
 }

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1,0 +1,34 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionInfo(t *testing.T) {
+	// Save and restore
+	origVersion := Version
+	origDate := Date
+	defer func() { Version = origVersion; Date = origDate }()
+
+	Version = "1.0.0"
+	Date = "2026-04-03"
+
+	info := VersionInfo()
+	assert.Contains(t, info, "1.0.0")
+	assert.Contains(t, info, "2026-04-03")
+	assert.Contains(t, info, "go")
+}
+
+func TestVersionInfo_DEV(t *testing.T) {
+	origVersion := Version
+	origDate := Date
+	defer func() { Version = origVersion; Date = origDate }()
+
+	Version = "DEV"
+	Date = ""
+
+	info := VersionInfo()
+	assert.Contains(t, info, "DEV")
+}

--- a/internal/copiacmd/root.go
+++ b/internal/copiacmd/root.go
@@ -33,7 +33,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 		SilenceUsage:  true,
 	}
 
-	cmd.SetVersionTemplate("copia-cli version {{.Version}}\n")
+	cmd.SetVersionTemplate(build.VersionInfo() + "\n")
 
 	// Global flags — bound to factory fields, resolved in ResolveAuth()
 	cmd.PersistentFlags().StringVar(&f.Host, "host", "", "Target Copia host")


### PR DESCRIPTION
## Summary

Closes #150

Enrich `copia-cli --version` output to show build details:

```
copia-cli version 1.0.0 (2026-04-03)
go: go1.26.1
os/arch: linux/amd64
```

### Changes
- `internal/build/build.go` — add `VersionInfo()` function
- `internal/build/build_test.go` — unit tests
- `internal/copiacmd/root.go` — use `VersionInfo()` in version template

## Test plan
- [x] Unit tests for VersionInfo (with date, without date)
- [x] All existing tests pass
- [x] Manual verify: `./bin/copia-cli --version`