### PR TITLE
chore: add test coverage reporting with codecov (#151)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
         run: make build
 
       - name: Test
-        run: make test
+        run: go test -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Ensure go.mod is tidy
         run: |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go](https://img.shields.io/badge/Go-1.26+-00ADD8.svg?logo=go&logoColor=white)](https://go.dev/)
 [![Release](https://img.shields.io/github/v/release/qubernetic/copia-cli?include_prereleases)](https://github.com/qubernetic/copia-cli/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
+[![codecov](https://codecov.io/gh/qubernetic/copia-cli/graph/badge.svg)](https://codecov.io/gh/qubernetic/copia-cli)
 
 </div>
 


### PR DESCRIPTION
## Summary

Closes #151

- CI workflow: `go test -coverprofile=coverage.out` + codecov upload
- README: codecov badge added

Requires `CODECOV_TOKEN` secret (already configured).