### PR TITLE
docs: add GoDoc package comments to all exported packages (#152)

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,3 +1,4 @@
+// Package build provides version and build information injected at compile time via ldflags.
 package build
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,5 @@
+// Package config manages the CLI configuration file (~/.config/copia/config.yml),
+// including host credentials, default host resolution, and file permissions.
 package config
 
 import (

--- a/internal/copiacmd/root.go
+++ b/internal/copiacmd/root.go
@@ -1,3 +1,4 @@
+// Package copiacmd provides the root command wiring and Main() entrypoint for the CLI.
 package copiacmd
 
 import (

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,3 +1,4 @@
+// Package api provides a Gitea SDK client wrapper for the Copia REST API.
 package api
 
 import (

--- a/pkg/cmdutil/factory.go
+++ b/pkg/cmdutil/factory.go
@@ -1,3 +1,6 @@
+// Package cmdutil provides shared CLI helpers including the Factory for
+// dependency injection, authentication resolution, repository detection,
+// JSON output flags, and command grouping utilities.
 package cmdutil
 
 import (

--- a/pkg/httpmock/registry.go
+++ b/pkg/httpmock/registry.go
@@ -1,3 +1,5 @@
+// Package httpmock provides an HTTP round-tripper mock for unit testing
+// CLI commands without making real API calls.
 package httpmock
 
 import (

--- a/pkg/iostreams/iostreams.go
+++ b/pkg/iostreams/iostreams.go
@@ -1,3 +1,5 @@
+// Package iostreams provides TTY-aware I/O abstraction for CLI commands,
+// with System() for production and Test() for unit testing.
 package iostreams
 
 import (


### PR DESCRIPTION
## Summary

Closes #152
Closes #156

### GoDoc comments (#152)
Add package-level documentation comments for pkg.go.dev:
api, cmdutil, iostreams, httpmock, config, build, copiacmd.

### Shell completion docs (#156)
Add shell completion install instructions to README (Bash, Zsh, Fish, PowerShell).