### PR TITLE
docs: add shell completion instructions (#156)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ $ copia-cli pr create --title "feat: add safety interlock" --base develop
 $ copia-cli pr merge 7 --merge --delete-branch
 ```
 
+## Shell Completion
+
+Shell completion is available for Bash, Zsh, Fish, and PowerShell. See `copia-cli completion --help` or the [manual](https://qubernetic.github.io/copia-cli/manual/copia-cli_completion) for setup instructions.
+
 ## Roadmap
 
 - **Phase 1 (MVP):** auth, repo list/view/clone, issue CRUD, pr CRUD, label list/create — **Done**

--- a/pkg/cmd/completion/completion.go
+++ b/pkg/cmd/completion/completion.go
@@ -12,21 +12,53 @@ func NewCmdCompletion(ios *iostreams.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "completion <shell>",
 		Short: "Generate shell completion scripts",
-		Long: `Generate completion scripts for bash, zsh, fish, or powershell.
+		Long: `Generate shell completion scripts for Copia CLI commands.
 
-To load completions:
+When installing Copia CLI through a package manager, it's possible that
+no additional shell configuration is necessary to gain completion support. For
+Homebrew, see <https://docs.brew.sh/Shell-Completion>
 
-  # Bash
-  source <(copia completion bash)
+If you need to set up completions manually, follow the instructions below. The exact
+config file locations might vary based on your system. Make sure to restart your
+shell before testing whether completions are working.
 
-  # Zsh
-  copia completion zsh > "${fpath[1]}/_copia"
+### bash
 
-  # Fish
-  copia completion fish | source
+First, ensure that you install ` + "`bash-completion`" + ` using your package manager.
 
-  # PowerShell
-  copia completion powershell | Out-String | Invoke-Expression`,
+After, add this to your ` + "`~/.bash_profile`" + `:
+
+    eval "$(copia-cli completion bash)"
+
+### zsh
+
+Generate a ` + "`_copia-cli`" + ` completion script and put it somewhere in your ` + "`$fpath`" + `:
+
+    copia-cli completion zsh > /usr/local/share/zsh/site-functions/_copia-cli
+
+Ensure that the following is present in your ` + "`~/.zshrc`" + `:
+
+    autoload -U compinit
+    compinit -i
+
+Zsh version 5.7 or later is recommended.
+
+### fish
+
+Generate a ` + "`copia-cli.fish`" + ` completion script:
+
+    copia-cli completion fish > ~/.config/fish/completions/copia-cli.fish
+
+### PowerShell
+
+Open your profile script with:
+
+    mkdir -Path (Split-Path -Parent $profile) -ErrorAction SilentlyContinue
+    notepad $profile
+
+Add the line and save the file:
+
+    Invoke-Expression -Command $(copia-cli completion powershell | Out-String)`,
 		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

Closes #156

- README: shell completion section with link to manual
- completion command: detailed Long description with per-shell setup (Bash, Zsh, Fish, PowerShell)