### PR TITLE
chore(deps): bump Go from 1.26.1 to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine
+FROM golang:1.26.2-alpine
 
 RUN apk add --no-cache git build-base
 

--- a/docs/project-layout.md
+++ b/docs/project-layout.md
@@ -79,9 +79,12 @@ copia-cli/
 │   └── httpmock/registry.go       # HTTP transport mock for testing
 ├── test/integration/              # Live API integration tests
 ├── .github/workflows/             # CI, CodeQL, release, govulncheck, bump-go
-├── .devcontainer/                 # Go 1.26.1, gh CLI, Claude Code
+├── .devcontainer/                 # Docker Compose-based dev environment
 ├── .goreleaser.yml                # Cross-platform release config
-└── Makefile                       # build, test, integration, clean
+├── justfile                       # Command runner (build, test, lint, dev)
+├── Dockerfile                     # Go 1.26.2 dev image
+├── docker-compose.yml             # Base compose config
+└── docker-compose.dev.yaml        # Dev overlay (source mount + caches)
 ```
 
 ## Module Guide

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qubernetic/copia-cli
 
-go 1.26.1
+go 1.26.2
 
 require (
 	code.gitea.io/sdk/gitea v0.24.1


### PR DESCRIPTION
## Summary

- Update Go version to 1.26.2 in go.mod, Dockerfile, and project-layout.md
- Supersedes #181 (bot PR only updated go.mod, missed Dockerfile)

Closes #186