### PR TITLE
ci: update bump-go workflow to also update Dockerfile

### DIFF
--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -30,11 +30,12 @@ jobs:
             echo "needs_update=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Update go.mod
+      - name: Update Go version
         if: steps.check.outputs.needs_update == 'true'
         run: |
           go mod edit -go=${{ steps.check.outputs.latest }}
           go mod tidy
+          sed -i "s|^FROM golang:.*-alpine|FROM golang:${{ steps.check.outputs.latest }}-alpine|" Dockerfile
 
       - name: Create Pull Request
         if: steps.check.outputs.needs_update == 'true'
@@ -44,8 +45,9 @@ jobs:
           commit-message: "chore(deps): bump Go from ${{ steps.check.outputs.current }} to ${{ steps.check.outputs.latest }}"
           title: "chore(deps): bump Go from ${{ steps.check.outputs.current }} to ${{ steps.check.outputs.latest }}"
           body: |
-            Auto-generated PR to update Go version in go.mod.
+            Auto-generated PR to update Go version.
 
             - Current: `${{ steps.check.outputs.current }}`
             - Latest: `${{ steps.check.outputs.latest }}`
+            - Files: `go.mod`, `Dockerfile`
           base: develop


### PR DESCRIPTION
## Summary

- Add `sed` step to update Dockerfile base image when Go version changes
- Update PR body template to list affected files

Closes #188