### PR TITLE
ci: add winget-releaser workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,16 @@
+name: Publish to WinGet
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Qubernetic.copia-cli
+          installers-regex: '\.zip$'
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If anything feels off, or if you feel that some functionality is missing, please
 
 ### [Windows](docs/install_windows.md)
 
+- [WinGet](docs/install_windows.md#winget)
 - [Precompiled binaries](docs/install_windows.md#precompiled-binaries) on [releases page][]
 
 ### Build from source

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -2,6 +2,12 @@
 
 ## Recommended _(Official)_
 
+### WinGet
+
+```pwsh
+winget install Qubernetic.copia-cli
+```
+
 ### Precompiled binaries
 
 [Copia CLI releases](https://github.com/qubernetic/copia-cli/releases/latest) contain precompiled `.zip` archives for `amd64`, `arm64`, and `386` architectures.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/winget.yml` — automated winget package publishing on release
- Update README and Windows install docs with `winget install Qubernetic.copia-cli`
- Requires `WINGET_TOKEN` repo secret (classic PAT, `public_repo` scope)

Closes #18