### PR TITLE
ci: add scheduled weekly integration test

### DIFF
--- a/.github/workflows/integration-scheduled.yml
+++ b/.github/workflows/integration-scheduled.yml
@@ -1,0 +1,41 @@
+name: Scheduled Integration Test
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly, Monday 6:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+
+      - name: Integration tests
+        run: go test -tags=integration -v ./...
+        env:
+          COPIA_TEST_TOKEN: ${{ secrets.COPIA_TEST_TOKEN }}
+          COPIA_TEST_HOST: ${{ secrets.COPIA_TEST_HOST }}
+          COPIA_TEST_OWNER: ${{ secrets.COPIA_TEST_OWNER }}
+          COPIA_TEST_REPO: ${{ secrets.COPIA_TEST_REPO }}
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const date = new Date().toISOString().split('T')[0];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              ...context.repo,
+              title: `ci: scheduled integration test failure (${date})`,
+              body: `The scheduled integration test failed.\n\nWorkflow run: ${runUrl}\n\nThis may indicate a Copia API change.`,
+              labels: ['bug']
+            });


### PR DESCRIPTION
## Summary

- Add weekly integration test workflow (Monday 06:00 UTC)
- Automatically creates a bug issue on failure with link to workflow run
- Uses existing `COPIA_TEST_*` secrets
- Supports manual trigger via `workflow_dispatch`

Closes #134