### PR TITLE
ci: add COPR package publishing for Fedora/RHEL

### DIFF
--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -1,0 +1,46 @@
+name: Publish to COPR
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  copr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install copr-cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip rpm
+          pip3 install copr-cli
+
+      - name: Configure copr-cli
+        run: |
+          mkdir -p ~/.config
+          cat > ~/.config/copr <<EOF
+          [copr-cli]
+          login = ${{ secrets.COPR_LOGIN }}
+          username = ${{ secrets.COPR_USERNAME }}
+          token = ${{ secrets.COPR_TOKEN }}
+          copr_url = https://copr.fedorainfracloud.org
+          EOF
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build SRPM
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          curl -sL "https://github.com/${{ github.repository }}/archive/v${VERSION}/${GITHUB_REPOSITORY##*/}-${VERSION}.tar.gz" \
+            -o rpmbuild/copia-cli-${VERSION}.tar.gz
+          rpmbuild -bs rpmbuild/copia-cli.spec \
+            --define "version ${VERSION}" \
+            --define "_sourcedir $(pwd)/rpmbuild" \
+            --define "_srcrpmdir $(pwd)/rpmbuild"
+
+      - name: Submit to COPR
+        run: |
+          copr-cli build copia-cli rpmbuild/copia-cli-*.src.rpm

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -26,15 +26,23 @@ curl -LO https://github.com/qubernetic/copia-cli/releases/latest/download/copia-
 sudo dpkg -i copia-cli_*_linux_amd64.deb
 ```
 
-### Fedora/RHEL (.rpm)
-
-Download the `.rpm` package from [GitHub Releases](https://github.com/qubernetic/copia-cli/releases/latest):
+### Fedora/RHEL (COPR)
 
 ```bash
-# Download the latest .rpm (amd64)
-curl -LO https://github.com/qubernetic/copia-cli/releases/latest/download/copia-cli_*_linux_amd64.rpm
+sudo dnf copr enable qubernetic/copia-cli
+sudo dnf install copia-cli
+```
 
-# Install
+To upgrade:
+
+```bash
+sudo dnf upgrade copia-cli
+```
+
+Alternatively, download the `.rpm` package directly from [GitHub Releases](https://github.com/qubernetic/copia-cli/releases/latest):
+
+```bash
+curl -LO https://github.com/qubernetic/copia-cli/releases/latest/download/copia-cli_*_linux_amd64.rpm
 sudo dnf install -y copia-cli_*_linux_amd64.rpm
 ```
 

--- a/rpmbuild/copia-cli.spec
+++ b/rpmbuild/copia-cli.spec
@@ -1,0 +1,33 @@
+%global goipath github.com/qubernetic/copia-cli
+
+Name:           copia-cli
+Version:        %{version}
+Release:        1%{?dist}
+Summary:        CLI for Copia — source control for industrial automation
+
+License:        AGPL-3.0-only
+URL:            https://%{goipath}
+Source0:        https://%{goipath}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  golang >= 1.26
+
+%description
+copia-cli brings Copia repositories, issues, pull requests, and other
+concepts to the terminal next to where you are already working with
+git and your code.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+go build -ldflags "-s -w -X %{goipath}/internal/build.Version=%{version} -X %{goipath}/internal/build.Date=$(date -u +%%Y-%%m-%%d)" -o %{name} ./cmd/copia-cli
+
+%install
+install -Dpm 0755 %{name} %{buildroot}%{_bindir}/%{name}
+install -Dpm 0644 LICENSE %{buildroot}%{_licensedir}/%{name}/LICENSE
+
+%files
+%license LICENSE
+%{_bindir}/%{name}
+
+%changelog


### PR DESCRIPTION
## Summary

- Add `rpmbuild/copia-cli.spec` — RPM spec for COPR builds
- Add `.github/workflows/copr.yml` — publishes to COPR on release
- Update Linux install docs with `dnf copr enable` instructions
- Requires `COPR_LOGIN`, `COPR_USERNAME`, `COPR_TOKEN` repo secrets

Closes #164