### PR TITLE
ci: add AUR package publishing for Arch Linux

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,0 +1,54 @@
+name: Publish to AUR
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  aur:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Get checksums
+        id: checksums
+        run: |
+          gh release download "${{ github.ref_name }}" --pattern "checksums.txt" --output checksums.txt
+          echo "sha256_x86_64=$(grep 'linux_amd64.tar.gz' checksums.txt | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          echo "sha256_aarch64=$(grep 'linux_arm64.tar.gz' checksums.txt | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3
+        with:
+          pkgname: copia-cli-bin
+          pkgbuild: |
+            # Maintainer: Qubernetic <hello@qubernetic.io>
+            pkgname=copia-cli-bin
+            pkgver=${{ steps.version.outputs.version }}
+            pkgrel=1
+            pkgdesc="CLI for Copia — source control for industrial automation"
+            arch=('x86_64' 'aarch64')
+            url="https://github.com/qubernetic/copia-cli"
+            license=('AGPL-3.0-only')
+            provides=('copia-cli')
+            conflicts=('copia-cli')
+
+            source_x86_64=("\${url}/releases/download/v\${pkgver}/copia-cli_\${pkgver}_linux_amd64.tar.gz")
+            source_aarch64=("\${url}/releases/download/v\${pkgver}/copia-cli_\${pkgver}_linux_arm64.tar.gz")
+            sha256sums_x86_64=('${{ steps.checksums.outputs.sha256_x86_64 }}')
+            sha256sums_aarch64=('${{ steps.checksums.outputs.sha256_aarch64 }}')
+
+            package() {
+                install -Dm755 copia-cli "\${pkgdir}/usr/bin/copia-cli"
+                install -Dm644 LICENSE "\${pkgdir}/usr/share/licenses/\${pkgname}/LICENSE"
+            }
+          commit_username: qubernetic
+          commit_email: hello@qubernetic.io
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/aur.yml` — updates AUR `copia-cli-bin` package on release
- Dynamically fetches checksums from release assets
- Uses `KSXGitHub/github-actions-deploy-aur@v3`
- Initial PKGBUILD already pushed to `aur.archlinux.org/copia-cli-bin.git`
- Requires `AUR_SSH_PRIVATE_KEY` repo secret

Closes #161