### PR TITLE
fix: correct workflow issues found during docs validation

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -23,32 +23,41 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate PKGBUILD
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          SHA_X86=${{ steps.checksums.outputs.sha256_x86_64 }}
+          SHA_ARM=${{ steps.checksums.outputs.sha256_aarch64 }}
+          cat > PKGBUILD <<PKGEOF
+          # Maintainer: Qubernetic <info@qubernetic.com>
+          pkgname=copia-cli-bin
+          pkgver=${VERSION}
+          pkgrel=1
+          pkgdesc="CLI for Copia — source control for industrial automation"
+          arch=('x86_64' 'aarch64')
+          url="https://github.com/qubernetic/copia-cli"
+          license=('AGPL-3.0-only')
+          provides=('copia-cli')
+          conflicts=('copia-cli')
+
+          source_x86_64=("\${url}/releases/download/v\${pkgver}/copia-cli_\${pkgver}_linux_amd64.tar.gz")
+          source_aarch64=("\${url}/releases/download/v\${pkgver}/copia-cli_\${pkgver}_linux_arm64.tar.gz")
+          sha256sums_x86_64=('${SHA_X86}')
+          sha256sums_aarch64=('${SHA_ARM}')
+
+          package() {
+              install -Dm755 copia-cli "\${pkgdir}/usr/bin/copia-cli"
+              install -Dm644 LICENSE "\${pkgdir}/usr/share/licenses/\${pkgname}/LICENSE"
+          }
+          PKGEOF
+          sed -i 's/^          //' PKGBUILD
+
       - name: Publish to AUR
         uses: KSXGitHub/github-actions-deploy-aur@v3
         with:
           pkgname: copia-cli-bin
-          pkgbuild: |
-            # Maintainer: Qubernetic <hello@qubernetic.io>
-            pkgname=copia-cli-bin
-            pkgver=${{ steps.version.outputs.version }}
-            pkgrel=1
-            pkgdesc="CLI for Copia — source control for industrial automation"
-            arch=('x86_64' 'aarch64')
-            url="https://github.com/qubernetic/copia-cli"
-            license=('AGPL-3.0-only')
-            provides=('copia-cli')
-            conflicts=('copia-cli')
-
-            source_x86_64=("\${url}/releases/download/v\${pkgver}/copia-cli_\${pkgver}_linux_amd64.tar.gz")
-            source_aarch64=("\${url}/releases/download/v\${pkgver}/copia-cli_\${pkgver}_linux_arm64.tar.gz")
-            sha256sums_x86_64=('${{ steps.checksums.outputs.sha256_x86_64 }}')
-            sha256sums_aarch64=('${{ steps.checksums.outputs.sha256_aarch64 }}')
-
-            package() {
-                install -Dm755 copia-cli "\${pkgdir}/usr/bin/copia-cli"
-                install -Dm644 LICENSE "\${pkgdir}/usr/share/licenses/\${pkgname}/LICENSE"
-            }
+          pkgbuild: ./PKGBUILD
           commit_username: qubernetic
-          commit_email: hello@qubernetic.io
+          commit_email: info@qubernetic.com
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update to ${{ steps.version.outputs.version }}"

--- a/.github/workflows/bump-go.yml
+++ b/.github/workflows/bump-go.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           ref: develop
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
       - name: Check latest Go version
         id: check
         run: |

--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -19,13 +19,9 @@ jobs:
       - name: Configure copr-cli
         run: |
           mkdir -p ~/.config
-          cat > ~/.config/copr <<EOF
-          [copr-cli]
-          login = ${{ secrets.COPR_LOGIN }}
-          username = ${{ secrets.COPR_USERNAME }}
-          token = ${{ secrets.COPR_TOKEN }}
-          copr_url = https://copr.fedorainfracloud.org
-          EOF
+          printf '[copr-cli]\nlogin = %s\nusername = %s\ntoken = %s\ncopr_url = https://copr.fedorainfracloud.org\n' \
+            "${{ secrets.COPR_LOGIN }}" "${{ secrets.COPR_USERNAME }}" "${{ secrets.COPR_TOKEN }}" \
+            > ~/.config/copr
 
       - name: Extract version
         id: version

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: vedantmgoyal9/winget-releaser@main
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,7 +77,7 @@ nfpms:
     package_name: copia-cli
     vendor: Qubernetic
     homepage: "https://github.com/qubernetic/copia-cli"
-    maintainer: "Qubernetic <hello@qubernetic.io>"
+    maintainer: "Qubernetic <info@qubernetic.com>"
     description: "CLI for Copia — source control for industrial automation"
     license: AGPL-3.0
     formats:


### PR DESCRIPTION
## Summary

- **aur.yml**: generate PKGBUILD to file — action expects path, not inline content
- **copr.yml**: fix heredoc indentation that broke INI parser
- **winget.yml**: use `ubuntu-slim` per official docs
- **bump-go.yml**: add `setup-go` step for `go mod tidy`
- **goreleaser + AUR**: update maintainer email to info@qubernetic.com

Closes #196