### PR TITLE
docs: update installation instructions with all package managers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ copia-cli/
 Phase 1 (MVP): auth, repo list/view/clone, issue CRUD, pr CRUD, label list/create — **DONE**
 Phase 2: release CRUD, repo create/delete/fork, pr review/diff/checkout, issue edit, Homebrew tap — **DONE**
 Phase 3: `copia-cli api` escape hatch, search, orgs, notifications, `-R` flag, completion, Jekyll manual, AGPL license — **DONE**
-Phase 4: winget, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks, changelog, collaborators
+Phase 4: ~~winget~~, ~~COPR~~, ~~AUR~~, ~~Snap~~, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks, changelog, collaborators
 
 **Out of scope:** workflow/run, codespace, copilot, project, cache, GUI
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ If anything feels off, or if you feel that some functionality is missing, please
 ### [Linux](docs/install_linux.md)
 
 - [Homebrew](docs/install_linux.md#homebrew)
+- [Fedora/RHEL (COPR)](docs/install_linux.md#fedorarhel-copr)
 - [Debian/Ubuntu (.deb)](docs/install_linux.md#debianubuntu-deb)
-- [Fedora/RHEL (.rpm)](docs/install_linux.md#fedorarhel-rpm)
+- [Snap](docs/install_linux.md#snap)
+- [AUR (Arch Linux)](docs/install_linux.md#aur-arch-linux)
 - [Precompiled binaries](docs/install_linux.md#precompiled-binaries) on [releases page][]
 
 ### [Windows](docs/install_windows.md)
@@ -74,7 +76,7 @@ Shell completion is available for Bash, Zsh, Fish, and PowerShell. See `copia-cl
 - **Phase 1 (MVP):** auth, repo list/view/clone, issue CRUD, pr CRUD, label list/create — **Done**
 - **Phase 2 (Workflow):** release CRUD, repo create/delete/fork, pr review/diff/checkout, issue edit, Homebrew tap — **Done**
 - **Phase 3 (Power Features):** `api` escape hatch, search, orgs, notifications, `-R`/`--repo` flag, completion, Jekyll manual, AGPL license — **Done**
-- **Phase 4 (Nice to Have):** winget, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks, scheduled integration tests
+- **Phase 4 (Nice to Have):** ~~winget~~, ~~COPR~~, ~~AUR~~, ~~Snap~~, OS keyring, aliases, browse, status dashboard, ssh-key, pr checks, scheduled integration tests
 
 ## License
 

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -46,6 +46,20 @@ curl -LO https://github.com/qubernetic/copia-cli/releases/latest/download/copia-
 sudo dnf install -y copia-cli_*_linux_amd64.rpm
 ```
 
+### Snap
+
+```bash
+sudo snap install copia-cli --classic
+```
+
+### AUR (Arch Linux)
+
+```bash
+yay -S copia-cli-bin
+```
+
+Or with any other AUR helper. The package is [`copia-cli-bin`](https://aur.archlinux.org/packages/copia-cli-bin).
+
 ### Precompiled binaries
 
 [Copia CLI releases](https://github.com/qubernetic/copia-cli/releases/latest) contain precompiled binaries for `amd64`, `arm64`, `386`, and `armv6` architectures.

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -19,17 +19,6 @@ winget install Qubernetic.copia-cli
 > [!NOTE]
 > When using Windows Terminal, you will need to **open a new window** for PATH changes to take effect.
 
-## Community _(Unofficial)_
-
-### Scoop
-
-```pwsh
-scoop install copia-cli
-```
-
-> [!NOTE]
-> Scoop support is community-maintained and may lag behind official releases.
-
 ## Building from source
 
 See [install_source.md](install_source.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,7 +35,12 @@
    - Uploads all artifacts to a GitHub Release (draft)
    - Updates the [Homebrew formula](https://github.com/qubernetic/homebrew-tap)
 
-7. Review and publish the draft release on GitHub
+7. Review and publish the draft release on GitHub. Publishing triggers:
+
+   - [WinGet](.github/workflows/winget.yml) — updates `Qubernetic.copia-cli` in winget-pkgs
+   - [COPR](.github/workflows/copr.yml) — builds and publishes RPM to Fedora COPR
+   - [AUR](.github/workflows/aur.yml) — updates `copia-cli-bin` on AUR
+   - [Snap](.github/workflows/snap.yml) — builds and publishes to the Snap Store
 
 8. Back-merge `main` into `develop`:
 
@@ -52,7 +57,7 @@ The release build is powered by [GoReleaser](https://goreleaser.com/). Configura
 To test the release locally without publishing:
 
 ```bash
-$ make snapshot
+$ just snapshot
 ```
 
 ## Pre-releases


### PR DESCRIPTION
## Summary

- Add Snap, AUR, COPR to README and Linux install docs
- Remove non-existent Scoop section from Windows install docs
- Update releasing.md with post-publish workflows and `just snapshot`
- Mark winget, COPR, AUR, Snap as done in roadmap

Closes #191