### PR TITLE
hotfix: fix COPR and Snap publish workflows

### DIFF
--- a/.github/workflows/copr.yml
+++ b/.github/workflows/copr.yml
@@ -31,11 +31,14 @@ jobs:
         run: |
           VERSION=${{ steps.version.outputs.version }}
           sed -i "s/^Version:.*$/Version:        ${VERSION}/" rpmbuild/copia-cli.spec
-          curl -sL "https://github.com/${{ github.repository }}/archive/v${VERSION}/copia-cli-${VERSION}.tar.gz" \
-            -o rpmbuild/copia-cli-${VERSION}.tar.gz
+          gh release download "v${VERSION}" --pattern "copia-cli_${VERSION}_linux_amd64.tar.gz" --output rpmbuild/copia-cli_${VERSION}_linux_amd64.tar.gz
+          gh release download "v${VERSION}" --pattern "copia-cli_${VERSION}_linux_arm64.tar.gz" --output rpmbuild/copia-cli_${VERSION}_linux_arm64.tar.gz
           rpmbuild -bs rpmbuild/copia-cli.spec \
             --define "_sourcedir $(pwd)/rpmbuild" \
-            --define "_srcrpmdir $(pwd)/rpmbuild"
+            --define "_srcrpmdir $(pwd)/rpmbuild" \
+            --target x86_64
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Submit to COPR
         run: |

--- a/rpmbuild/copia-cli.spec
+++ b/rpmbuild/copia-cli.spec
@@ -7,9 +7,13 @@ Summary:        CLI for Copia — source control for industrial automation
 
 License:        AGPL-3.0-only
 URL:            https://%{goipath}
-Source0:        https://%{goipath}/archive/v%{version}/%{name}-%{version}.tar.gz
 
-BuildRequires:  golang >= 1.26
+%ifarch x86_64
+Source0:        https://%{goipath}/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz
+%endif
+%ifarch aarch64
+Source0:        https://%{goipath}/releases/download/v%{version}/%{name}_%{version}_linux_arm64.tar.gz
+%endif
 
 %description
 copia-cli brings Copia repositories, issues, pull requests, and other
@@ -17,10 +21,7 @@ concepts to the terminal next to where you are already working with
 git and your code.
 
 %prep
-%autosetup -n %{name}-%{version}
-
-%build
-go build -ldflags "-s -w -X %{goipath}/internal/build.Version=%{version} -X %{goipath}/internal/build.Date=$(date -u +%%Y-%%m-%%d)" -o %{name} ./cmd/copia-cli
+%setup -c
 
 %install
 install -Dpm 0755 %{name} %{buildroot}%{_bindir}/%{name}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
     source: .
     source-type: local
     build-snaps:
-      - go/1.26/stable
+      - go/latest/stable
     go-buildtags: []
     go-generate: []
     override-build: |


### PR DESCRIPTION
## Summary

- **COPR**: rewrite spec to download pre-built binaries from GitHub Releases instead of building from source (Go 1.26 not available in Fedora repos)
- **Snap**: use `go/latest/stable` channel (`go/1.26/stable` doesn't exist, causing indefinite hang)

Closes #203