### PR TITLE
hotfix: disable debug package in COPR spec

### DIFF
--- a/rpmbuild/copia-cli.spec
+++ b/rpmbuild/copia-cli.spec
@@ -1,4 +1,5 @@
 %global goipath github.com/qubernetic/copia-cli
+%global debug_package %{nil}
 
 Name:           copia-cli
 Version:        0.0.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,8 +24,14 @@ parts:
       - go/latest/stable
     go-buildtags: []
     go-generate: []
+    build-environment:
+      - CGO_ENABLED: "0"
     override-build: |
       go build -ldflags "-s -w -X github.com/qubernetic/copia-cli/internal/build.Version=$(git describe --tags --always) -X github.com/qubernetic/copia-cli/internal/build.Date=$(date -u +%Y-%m-%d)" -o $CRAFT_PART_INSTALL/bin/copia-cli ./cmd/copia-cli
+
+lint:
+  ignore:
+    - classic
 
 apps:
   copia-cli:


### PR DESCRIPTION
## Summary

Pre-built Go binaries are stripped — `find-debuginfo` produces an empty `debugsourcefiles.list` which fails the RPM build on COPR.

Fix: add `%global debug_package %{nil}` to spec.

Part of #203