### PR TITLE
hotfix: fix COPR multi-arch and Snap credentials

### DIFF
--- a/rpmbuild/copia-cli.spec
+++ b/rpmbuild/copia-cli.spec
@@ -9,12 +9,8 @@ Summary:        CLI for Copia — source control for industrial automation
 License:        AGPL-3.0-only
 URL:            https://%{goipath}
 
-%ifarch x86_64
 Source0:        https://%{goipath}/releases/download/v%{version}/%{name}_%{version}_linux_amd64.tar.gz
-%endif
-%ifarch aarch64
-Source0:        https://%{goipath}/releases/download/v%{version}/%{name}_%{version}_linux_arm64.tar.gz
-%endif
+Source1:        https://%{goipath}/releases/download/v%{version}/%{name}_%{version}_linux_arm64.tar.gz
 
 %description
 copia-cli brings Copia repositories, issues, pull requests, and other
@@ -22,7 +18,12 @@ concepts to the terminal next to where you are already working with
 git and your code.
 
 %prep
-%setup -c
+%ifarch x86_64
+%setup -c -T -a 0
+%endif
+%ifarch aarch64
+%setup -c -T -a 1
+%endif
 
 %install
 install -Dpm 0755 %{name} %{buildroot}%{_bindir}/%{name}


### PR DESCRIPTION
## Summary

- **COPR**: use dual Source entries (Source0=amd64, Source1=arm64) with `%ifarch` in `%prep` so both architectures are included in the SRPM. Previously only x86_64 source was packaged, causing all aarch64 builds to fail.
- **Snap**: credentials issue was missing `[login.ubuntu.com]` INI header — secret already updated.

Closes #203