### PR TITLE
hotfix: switch Snap to strict confinement

### DIFF
--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -49,8 +49,11 @@ sudo dnf install -y copia-cli_*_linux_amd64.rpm
 ### Snap
 
 ```bash
-sudo snap install copia-cli --classic
+sudo snap install copia-cli
 ```
+
+> [!NOTE]
+> The Snap uses strict confinement — it can only access files in your home directory. If you work with git repositories outside `$HOME`, use a different installation method.
 
 ### AUR (Arch Linux)
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 
 base: core24
 grade: stable
-confinement: classic
+confinement: strict
 license: AGPL-3.0
 
 platforms:
@@ -29,10 +29,9 @@ parts:
     override-build: |
       go build -ldflags "-s -w -X github.com/qubernetic/copia-cli/internal/build.Version=$(git describe --tags --always) -X github.com/qubernetic/copia-cli/internal/build.Date=$(date -u +%Y-%m-%d)" -o $CRAFT_PART_INSTALL/bin/copia-cli ./cmd/copia-cli
 
-lint:
-  ignore:
-    - classic
-
 apps:
   copia-cli:
     command: bin/copia-cli
+    plugs:
+      - network
+      - home


### PR DESCRIPTION
## Summary

- Switch from `classic` to `strict` confinement (classic requires manual Snap Store review)
- Add `network` + `home` plugs for API access and config file support
- Remove `lint: ignore: classic` (no longer needed)
- Add limitation note to install docs

Part of #203